### PR TITLE
Update abi and indices of golos.ctrl, golos.emit, golos.vesting #136

### DIFF
--- a/golos.ctrl/abi/golos.ctrl.abi
+++ b/golos.ctrl/abi/golos.ctrl.abi
@@ -1,6 +1,5 @@
 {
-    "____comment": "This file was generated with eosio-abigen. DO NOT EDIT Sun Sep 23 11:20:59 2018",
-    "version": "eosio::abi/1.0",
+    "version": "cyberway::abi/1.0",
     "types": [{
         "new_type_name": "account_name",
         "type": "name"
@@ -27,7 +26,7 @@
             "name": "bw_user",
             "base": "",
             "fields": [
-                {"type": "account_name", "name": "name"},
+                {"type": "name", "name": "name"},
                 {"type": "bool", "name": "attached"}
             ]
         },
@@ -35,7 +34,7 @@
             "name": "ctrl_props",
             "base": "",
             "fields": [
-                {"type": "account_name", "name": "owner"},
+                {"type": "name", "name": "owner"},
                 {"type": "properties", "name": "props"}
             ]
         },
@@ -124,7 +123,7 @@
             "name": "witness_info",
             "base": "",
             "fields": [
-                {"type": "account_name", "name": "name"},
+                {"type": "name", "name": "name"},
                 {"type": "public_key", "name": "key"},
                 {"type": "string", "name": "url"},
                 {"type": "bool", "name": "active"},
@@ -135,7 +134,7 @@
             "name": "witness_voter_s",
             "base": "",
             "fields": [
-                {"type": "account_name", "name": "community"},
+                {"type": "name", "name": "community"},
                 {"type": "account_name[]", "name": "witnesses"}
             ]
         }
@@ -192,30 +191,42 @@
         {
             "name": "bwuser",
             "type": "bw_user",
-            "index_type": "i64",
-            "key_names": [],
-            "key_types": []
+            "indexes" : [{
+                "name": "primary",
+                "unique": true,
+                "orders": [{"field": "name", "order": "asc"}]
+            }]
         },
         {
             "name": "props",
             "type": "ctrl_props",
-            "index_type": "i64",
-            "key_names": [],
-            "key_types": []
+            "indexes" : [{
+                "name": "primary",
+                "unique": true,
+                "orders": [{"field": "owner", "order": "asc"}]
+            }]
         },
         {
             "name": "witness",
             "type": "witness_info",
-            "index_type": "i64",
-            "key_names": ["byweight"],
-            "key_types": ["uint64"]
+            "indexes" : [{
+                "name": "primary",
+                "unique": true,
+                "orders": [{"field": "name", "order": "asc"}]
+            },{
+                "name": "byweight",
+                "unique": false,
+                "orders": [{"field": "total_weight", "order": "desc"}]
+            }]
         },
         {
             "name": "witnessvote",
             "type": "witness_voter_s",
-            "index_type": "i64",
-            "key_names": [],
-            "key_types": []
+            "indexes" : [{
+                "name": "primary",
+                "unique": true,
+                "orders": [{"field": "community", "order": "asc"}]
+            }]
         }
     ],
     "ricardian_clauses": [],

--- a/golos.ctrl/include/golos.ctrl/golos.ctrl.hpp
+++ b/golos.ctrl/include/golos.ctrl/golos.ctrl.hpp
@@ -78,7 +78,8 @@ struct [[eosio::table]] witness_info {
         return name;
     }
     uint64_t weight_key() const {
-        return std::numeric_limits<uint64_t>::max() - total_weight;     // TODO: resolve case where 2+ same weights exist (?extend key to 128bit)
+        // return std::numeric_limits<uint64_t>::max() - total_weight;     // TODO: resolve case where 2+ same weights exist (?extend key to 128bit)
+        return total_weight;     // TODO: resolve case where 2+ same weights exist (?extend key to 128bit)
     }
 };
 using witness_weight_idx = indexed_by<N(byweight), const_mem_fun<witness_info, uint64_t, &witness_info::weight_key>>;

--- a/golos.ctrl/src/golos.ctrl.cpp
+++ b/golos.ctrl/src/golos.ctrl.cpp
@@ -246,7 +246,7 @@ vector<witness_info> control::top_witness_info() {
     const auto l = props().max_witnesses;
     top.reserve(l);
     witness_tbl witness(_self, _token);
-    auto idx = witness.get_index<N(byweight)>();
+    auto idx = witness.get_index<N(byweight)>();    // this index ordered descending
     for (auto itr = idx.begin(); itr != idx.end() && top.size() < l; ++itr) {
         if (itr->active && itr->total_weight > 0)
             top.emplace_back(*itr);

--- a/golos.emit/CMakeLists.txt
+++ b/golos.emit/CMakeLists.txt
@@ -4,7 +4,7 @@ target_include_directories(golos.emit.wasm
    PUBLIC
    ${CMAKE_CURRENT_SOURCE_DIR}/include
    ${CMAKE_CURRENT_SOURCE_DIR}/../golos.ctrl/include
-   ${CMAKE_CURRENT_SOURCE_DIR}/../golos.contracts/eosio.token/include
+   ${CMAKE_CURRENT_SOURCE_DIR}/../cyberway.contracts/eosio.token/include
    ${CMAKE_CURRENT_SOURCE_DIR}/..)
 
 set_target_properties(golos.emit.wasm

--- a/golos.emit/abi/golos.emit.abi
+++ b/golos.emit/abi/golos.emit.abi
@@ -1,6 +1,5 @@
 {
-    "____comment": "This file was generated with eosio-abigen. DO NOT EDIT Mon Oct 20 16:06:14 2018",
-    "version": "eosio::abi/1.0",
+    "version": "cyberway::abi/1.0",
     "types": [{
         "new_type_name": "account_name",
         "type": "name"
@@ -56,9 +55,11 @@
         {
             "name": "state",
             "type": "state",
-            "index_type": "i64",
-            "key_names": [],
-            "key_types": []
+            "indexes" : [{
+                "name": "primary",
+                "unique": true,
+                "orders": [{"field": "id", "order": "asc"}]
+            }]
         }
     ],
     "ricardian_clauses": [],

--- a/golos.publication/golos.publication.hpp
+++ b/golos.publication/golos.publication.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include "objects.hpp"
 
-namespace eosio { 
+namespace eosio {
 
 class publication : public eosio::contract {
   public:
@@ -9,11 +9,11 @@ class publication : public eosio::contract {
     void apply(uint64_t code, uint64_t action);
 
   private:
-    void set_rules(const funcparams& mainfunc, const funcparams& curationfunc, 
-                     const funcparams& timepenalty, int64_t curatorsprop, 
-                     int64_t maxtokenprop, eosio::symbol_type tokensymbol, 
+    void set_rules(const funcparams& mainfunc, const funcparams& curationfunc,
+                     const funcparams& timepenalty, int64_t curatorsprop,
+                     int64_t maxtokenprop, eosio::symbol_type tokensymbol,
                      limitsarg lims_arg);
-    void on_transfer(account_name from, account_name to, 
+    void on_transfer(account_name from, account_name to,
                      eosio::asset quantity, std::string memo);
     void create_message(account_name account, std::string permlink,
                      account_name parentacc, std::string parentprmlnk,
@@ -31,29 +31,29 @@ class publication : public eosio::contract {
     void downvote(account_name voter, account_name author, std::string permlink, int16_t weight);
     void unvote(account_name voter, account_name author, std::string permlink);
     void create_acc(account_name name);
- 
+
     void close_message(account_name account, uint64_t id);
     void close_message_timer(account_name account, uint64_t id);
     void set_vote(account_name voter, account_name author, uint64_t id, int16_t weight);
     uint16_t notify_parent(bool increase, account_name parentacc, uint64_t parent_id);
-    void fill_depleted_pool(tables::reward_pools& pools, eosio::asset quantity, 
+    void fill_depleted_pool(tables::reward_pools& pools, eosio::asset quantity,
                      tables::reward_pools::const_iterator excluded);
     auto get_pool(tables::reward_pools& pools, uint64_t time);
     int64_t pay_curators(account_name author, uint64_t msgid, int64_t max_rewards,
                      fixp_t weights_sum, eosio::symbol_type tokensymbol);
     void payto(account_name user, eosio::asset quantity, enum_t mode);
     void check_account(account_name user, eosio::symbol_type tokensymbol);
-    elaf_t apply_limits(atmsp::machine<fixp_t>& machine, 
-                    account_name user, const structures::rewardpool& pool, 
-                    structures::limits::kind_t kind, uint64_t cur_time, 
+    elaf_t apply_limits(atmsp::machine<fixp_t>& machine,
+                    account_name user, const structures::rewardpool& pool,
+                    structures::limits::kind_t kind, uint64_t cur_time,
                     elaf_t w);
-         
-    
-    static structures::funcinfo load_func(const funcparams& params, const std::string& name, 
-                     const atmsp::parser<fixp_t>& pa, atmsp::machine<fixp_t>& machine, bool inc);                    
-    static atmsp::storable::bytecode load_restorer_func(const std::string str_func, 
+
+
+    static structures::funcinfo load_func(const funcparams& params, const std::string& name,
+                     const atmsp::parser<fixp_t>& pa, atmsp::machine<fixp_t>& machine, bool inc);
+    static atmsp::storable::bytecode load_restorer_func(const std::string str_func,
                      const atmsp::parser<fixp_t>& pa, atmsp::machine<fixp_t>& machine);
-    static fixp_t get_delta(atmsp::machine<fixp_t>& machine, fixp_t old_val, fixp_t new_val, 
+    static fixp_t get_delta(atmsp::machine<fixp_t>& machine, fixp_t old_val, fixp_t new_val,
                      const structures::funcinfo& func);
 };
 

--- a/golos.publication/utils.hpp
+++ b/golos.publication/utils.hpp
@@ -3,13 +3,15 @@
 #include "config.hpp"
 #include "objects.hpp"
 #include <common/calclib/atmsp_storable.h>
+
 using namespace golos::config;
+
 template<typename T, typename F>
-auto get_itr(T& tbl, uint64_t key, account_name payer, F&& insert_fn) {    
+auto get_itr(T& tbl, uint64_t key, account_name payer, F&& insert_fn) {
     auto itr = tbl.find(key);
     if(itr == tbl.end())
         itr = tbl.emplace(payer, insert_fn);
-    return itr;    
+    return itr;
 }
 
 fixp_t set_and_run(atmsp::machine<fixp_t>& machine, const atmsp::storable::bytecode& bc, const std::vector<fixp_t>& args, const std::vector<std::pair<fixp_t, fixp_t> >& domain = {}) {
@@ -31,13 +33,13 @@ fixp_t get_prop(int64_t arg) {
 }
 
 void check_positive_monotonic(atmsp::machine<fixp_t>& machine, fixp_t max_arg, const std::string& name, bool inc) {
-    
+
     fixp_t prev_res = machine.run({max_arg});
     if(!inc)
         eosio_assert(prev_res >= fixp_t(0), ("check positive failed for " + name).c_str());
     fixp_t cur_arg = max_arg;
     for(size_t i = 0; i < CHECK_MONOTONIC_STEPS; i++) {
-        cur_arg /= fixp_t(2);           
+        cur_arg /= fixp_t(2);
         fixp_t cur_res = machine.run({cur_arg});
         eosio_assert(inc ? (cur_res <= prev_res) : (cur_res >= prev_res), ("check monotonic failed for " + name).c_str());
         prev_res = cur_res;

--- a/golos.vesting/golos.vesting.abi
+++ b/golos.vesting/golos.vesting.abi
@@ -1,5 +1,5 @@
 {
-  "version": "eosio::abi/1.0",
+  "version": "cyberway::abi/1.0",
   "types": [
     {
       "new_type_name": "account_name",
@@ -11,14 +11,8 @@
       "name": "balance_vesting",
       "base": "",
       "fields": [
-        {
-          "name": "supply",
-          "type": "asset"
-        },
- 	{
-          "name": "issuers",
-          "type": "account_name[]"
-        }
+        {"name": "supply", "type": "asset"},
+        {"name": "issuers", "type": "account_name[]"}
       ]
     },
     {
@@ -97,7 +91,7 @@
       "fields": [
         {
           "name": "sender",
-          "type": "account_name"
+          "type": "name"
         },
         {
           "name": "recipient",
@@ -316,57 +310,69 @@
     {
       "name": "vesting",
       "type": "balance_vesting",
-      "index_type": "i64",
-      "key_names": [
-        "currency"
-      ],
-      "key_types": [
-        "uint64"
-      ]
+      "indexes" : [{
+          "name": "primary",
+          "unique": true,
+          "orders": [{"field": "supply.sym", "order": "asc"}]
+      }]
     },
     {
       "name": "balances",
       "type": "user_balance",
-      "index_type": "i64",
-      "key_names": [
-        "currency"
-      ],
-      "key_types": [
-        "uint64"
-      ]
+      "indexes" : [{
+          "name": "primary",
+          "unique": true,
+          "orders": [{"field": "vesting.sym", "order": "asc"}]
+      }]
     },
     {
       "name": "delegate",
       "type": "delegate_record",
-      "index_type": "i64",
-      "key_names": [
-        "id"
-      ],
-      "key_types": [
-        "uint64"
-      ]
+      "indexes" : [{
+          "name": "primary",
+          "unique": true,
+          "orders": [{"field": "id", "order": "asc"}]
+      },{
+          "name": "sender",
+          "unique": false,
+          "orders": [{"field": "sender", "order": "asc"}]
+      },{
+          "name": "recipient",
+          "unique": false,
+          "orders": [{"field": "recipient", "order": "asc"}]
+      },{
+          "name": "unique",
+          "unique": false,
+          "orders": [
+            {"field": "recipient", "order": "asc"}
+            {"field": "sender", "order": "asc"}]
+      }]
     },
     {
       "name": "rdelegate",
       "type": "return_delegate",
-      "index_type": "i64",
-      "key_names": [
-        "id"
-      ],
-      "key_types": [
-        "uint64"
-      ]
+      "indexes" : [{
+          "name": "primary",
+          "unique": true,
+          "orders": [{"field": "id", "order": "asc"}]
+      },{
+          "name": "date",
+          "unique": false,
+          "orders": [{"field": "date", "order": "asc"}]
+      }]
     },
     {
       "name": "converttable",
       "type": "convert_of_tokens",
-      "index_type": "i64",
-      "key_names": [
-        "sender"
-      ],
-      "key_types": [
-        "account_name"
-      ]
+      "indexes" : [{
+          "name": "primary",
+          "unique": true,
+          "orders": [{"field": "sender", "order": "asc"}]
+      },{
+          "name": "payouttime",
+          "unique": false,
+          "orders": [{"field": "payout_time", "order": "asc"}]
+      }]
     }
   ],
   "ricardian_clauses": [],

--- a/golos.vesting/objects.hpp
+++ b/golos.vesting/objects.hpp
@@ -33,17 +33,17 @@ struct user_balance
     asset unlocked_limit;
 
     uint64_t primary_key() const {
-        return vesting.symbol.name();
+        return vesting.symbol;//.name();
     }
-    
+
     asset available_vesting() const {
         return vesting - delegate_vesting;
     }
-    
+
     asset effective_vesting() const {
-        return (vesting - delegate_vesting) + received_vesting; 
+        return (vesting - delegate_vesting) + received_vesting;
     }
-    
+
     asset unlocked_vesting() const {
         return std::min(available_vesting(), unlocked_limit);
     }


### PR DESCRIPTION
1. update abi
2. descending weight index in `golos.ctrl`
3. fix `golos.emit` build
4. kill trailing spaces in `golos.publication`
5. `golos.vesting` conversion table primary key is now `symbol`
6. use updated `cyberway.contracts`