### PR TITLE
Emission base tests + fixes of ctrl/vesting tests #132

### DIFF
--- a/common/config.hpp
+++ b/common/config.hpp
@@ -6,7 +6,7 @@ namespace golos { namespace config {
 static const auto control_name = N(gls.ctrl);
 static const auto vesting_name = N(gls.vesting);
 static const auto emission_name = N(gls.emit);
-static const auto publication_name = N(gls.publish);
+static const auto workers_name = N(gls.worker);
 static const auto token_name = N(eosio.token);
 static const auto internal_name = N(eosio);
 

--- a/common/upsert.hpp
+++ b/common/upsert.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include <eosiolib/eosio.hpp>
 
 namespace golos {

--- a/golos.ctrl/include/golos.ctrl/config.hpp
+++ b/golos.ctrl/include/golos.ctrl/config.hpp
@@ -3,6 +3,6 @@
 
 namespace golos { namespace config {
 
-
+static const auto witness_max_url_size = 256;
 
 } } // golos::config

--- a/golos.ctrl/include/golos.ctrl/golos.ctrl.hpp
+++ b/golos.ctrl/include/golos.ctrl/golos.ctrl.hpp
@@ -24,7 +24,7 @@ struct [[eosio::table]] properties {
     // emission
     uint16_t infrate_start = 1500;          // INFLATION_RATE_START_PERCENT
     uint16_t infrate_stop = 95;             // INFLATION_RATE_STOP_PERCENT
-    uint32_t infrate_narrowing = 250000*6;  // INFLATION_NARROWING_PERIOD
+    uint32_t infrate_narrowing = 250000;    // INFLATION_NARROWING_PERIOD
     uint16_t content_reward = 6667-667;     // CONTENT_REWARD_PERCENT
     uint16_t vesting_reward = 2667-267;     // VESTING_FUND_PERCENT
     uint16_t workers_reward = 1000;         // 10%
@@ -78,7 +78,6 @@ struct [[eosio::table]] witness_info {
         return name;
     }
     uint64_t weight_key() const {
-        // return std::numeric_limits<uint64_t>::max() - total_weight;     // TODO: resolve case where 2+ same weights exist (?extend key to 128bit)
         return total_weight;     // TODO: resolve case where 2+ same weights exist (?extend key to 128bit)
     }
 };
@@ -94,28 +93,11 @@ struct [[eosio::table]] witness_voter_s {
         return community;
     }
 };
-
-// weighted version
-// struct [[eosio::table]] witness_vote {
-//     account_name witness;
-//     uint64_t weight;
-// };
-
-// struct [[eosio::table]] witness_voter_w {
-//     account_name community;
-//     std::vector<witness_vote> votes;
-
-//     uint64_t primary_key() const {
-//         return community;
-//     }
-// };
-// using witness_voter = witness_voter_s;
 using witness_vote_tbl = eosio::multi_index<N(witnessvote), witness_voter_s>;
 
 
 struct [[eosio::table]] bw_user {   // ?needed or simple names vector will be enough?
     account_name name;
-    // time_point_sec when;    // TODO: auto-expire can be added
     bool attached;          // can delete whole record on detach
 
     uint64_t primary_key() const {

--- a/golos.ctrl/src/golos.ctrl.cpp
+++ b/golos.ctrl/src/golos.ctrl.cpp
@@ -2,7 +2,6 @@
 #include "golos.ctrl/config.hpp"
 #include <golos.vesting/golos.vesting.hpp>
 #include <eosio.system/native.hpp>
-#include <eosiolib/transaction.hpp>
 
 #define DOMAIN_TYPE symbol_type
 #include <common/dispatcher.hpp>
@@ -12,8 +11,6 @@ namespace golos {
 using namespace eosio;
 using std::vector;
 using std::string;
-
-#define MAX_WITNESS_URL_SIZE 256
 
 
 /// properties
@@ -82,9 +79,8 @@ void control::detachacc(account_name user) {
 }
 
 void control::regwitness(account_name witness, eosio::public_key key, string url) {
-    eosio_assert(url.length() <= MAX_WITNESS_URL_SIZE, "url too long");
+    eosio_assert(url.length() <= config::witness_max_url_size, "url too long");
     eosio_assert(key != eosio::public_key(), "public key should not be the default value");
-    // TODO: check if key unique? Actually, key became unused now, can be removed
     require_auth(witness);
 
     upsert_tbl<witness_tbl>(_token, witness, witness, [&](bool exists) {
@@ -212,7 +208,7 @@ void control::update_auths() {
         auth.accounts.push_back({{i,config::active_name},1});
     }
 
-    std::vector<std::pair<uint64_t,uint16_t>> auths = {
+    vector<std::pair<uint64_t,uint16_t>> auths = {
         {config::minority_name, props().minority_threshold()},
         {config::majority_name, props().majority_threshold()},
         {config::active_name, props().active_threshold()}         // active must be the last because it adds eosio.code

--- a/golos.emit/include/golos.emit/config.hpp
+++ b/golos.emit/include/golos.emit/config.hpp
@@ -3,6 +3,6 @@
 
 namespace golos { namespace config {
 
-static const auto emit_period = 15*60;      // 15 minutes
+static const auto emit_interval = 15*60;      // 15 minutes
 
 } } // golos::config

--- a/golos.emit/src/golos.emit.cpp
+++ b/golos.emit/src/golos.emit.cpp
@@ -29,14 +29,14 @@ void emission::start() {
         .post_name = _owner,
         // .work_name = p.workers_pool,
         .start_time = current_time(),
-        .prev_emit = current_time() - config::emit_period*1000'000   // instant emit. TODO: maybe delay on first start?
+        .prev_emit = current_time() - config::emit_interval*1000'000   // instant emit. TODO: maybe delay on first start?
     };
     s = _state.get_or_create(_owner, s);
     eosio_assert(!s.active, "already active");
     s.active = true;
 
     uint32_t elapsed = (current_time() - s.prev_emit) / 1e6;
-    auto delay = elapsed < config::emit_period ? config::emit_period - elapsed : 0;
+    auto delay = elapsed < config::emit_interval ? config::emit_interval - elapsed : 0;
     schedule_next(s, delay);
 }
 
@@ -59,8 +59,8 @@ void emission::emit() {
     eosio_assert(s.active, "emit called in inactive state");    // impossible?
     auto now = current_time();
     auto elapsed = now - s.prev_emit;
-    if (elapsed != 1e6 * config::emit_period) {
-        eosio_assert(elapsed > config::emit_period, "emit called too early");   // impossible?
+    if (elapsed != 1e6 * config::emit_interval) {
+        eosio_assert(elapsed > config::emit_interval, "emit called too early");   // impossible?
         print("warning: emit call delayed. elapsed: ", elapsed);
     }
     // TODO: maybe limit elapsed to avoid instant high value emission
@@ -110,7 +110,7 @@ void emission::emit() {
     }
 
     s.prev_emit = current_time();
-    schedule_next(s, config::emit_period);
+    schedule_next(s, config::emit_interval);
 }
 
 void emission::schedule_next(state& s, uint32_t delay) {

--- a/tests/contracts.hpp.in
+++ b/tests/contracts.hpp.in
@@ -9,6 +9,8 @@ namespace eosio { namespace testing {
 struct contracts {
     static std::vector<uint8_t> ctrl_wasm() { return read_wasm(GOLOS_CONTRACTS "golos.ctrl/golos.ctrl.wasm"); }
     static std::vector<char>    ctrl_abi()  { return read_abi (GOLOS_CONTRACTS "golos.ctrl/golos.ctrl.abi"); }
+    static std::vector<uint8_t> emit_wasm() { return read_wasm(GOLOS_CONTRACTS "golos.emit/golos.emit.wasm"); }
+    static std::vector<char>    emit_abi()  { return read_abi (GOLOS_CONTRACTS "golos.emit/golos.emit.abi"); }
     static std::vector<uint8_t> vesting_wasm() { return read_wasm(GOLOS_CONTRACTS "golos.vesting/golos.vesting.wasm"); }
     static std::vector<char>    vesting_abi()  { return read_abi (GOLOS_CONTRACTS "golos.vesting/golos.vesting.abi"); }
     static std::vector<uint8_t> posting_wasm() { return read_wasm(GOLOS_CONTRACTS "golos.publication/golos.publication.wasm"); }

--- a/tests/eosio.token_test_api.hpp
+++ b/tests/eosio.token_test_api.hpp
@@ -24,6 +24,14 @@ struct eosio_token_api: base_contract_api {
         );
     }
 
+    action_result open(account_name owner, symbol symbol, account_name payer) {
+        return push(N(open), owner, args()
+            ("owner", owner)
+            ("symbol", symbol)
+            ("ram_payer", payer)
+        );
+    }
+
     action_result transfer(account_name from, account_name to, asset quantity, string memo) {
         return push(N(transfer), from, args()
             ("from", from)

--- a/tests/golos.ctrl_test_api.hpp
+++ b/tests/golos.ctrl_test_api.hpp
@@ -92,6 +92,22 @@ struct golos_ctrl_api: domain_contract_api<symbol> {
     }
 
     //// helpers
+    static mvo default_params(uint16_t witnesses, uint16_t witness_votes, account_name worker) {
+        return mvo()
+            ("max_witnesses", witnesses)
+            ("max_witness_votes", witness_votes)
+            ("witness_supermajority", 0)
+            ("witness_majority", 0)
+            ("witness_minority", 0)
+            ("infrate_start", 1500)
+            ("infrate_stop", 95)
+            ("infrate_narrowing", 250000)
+            ("content_reward", 6667-667)
+            ("vesting_reward", 2667-267)
+            ("workers_reward", 1000)
+            ("workers_pool", worker.to_string());
+    }
+
     void prepare_owner(account_name owner) {
         // witn.major/minor
         auto auth = authority(1, {}, {
@@ -103,14 +119,15 @@ struct golos_ctrl_api: domain_contract_api<symbol> {
         _tester->link_authority(owner, _code, _minority_name, N(attachacc));
         _tester->link_authority(owner, _code, _minority_name, N(detachacc));
 
-        //eosio.code
+        // eosio.code
         auto code_auth = authority(1, {}, {
             {.permission = {_code, config::eosio_code_name}, .weight = 1}
         });
         _tester->set_authority(owner, config::owner_name, code_auth, 0);
         code_auth.keys = {{_tester->get_public_key(owner, "active"), 1}};
         _tester->set_authority(owner, config::active_name, code_auth, "owner",
-            {permission_level{owner, config::active_name}}, {_tester->get_private_key("blog", "active")});
+            {permission_level{owner, config::active_name}},
+            {_tester->get_private_key(owner.to_string(), "active")});
     }
 
 };

--- a/tests/golos.emit_test_api.hpp
+++ b/tests/golos.emit_test_api.hpp
@@ -1,0 +1,37 @@
+#pragma once
+#include "test_api_helper.hpp"
+
+namespace eosio { namespace testing {
+
+
+struct golos_emit_api: domain_contract_api<symbol> {
+    using domain_contract_api::domain_contract_api;
+
+    //// emit actions
+    action_result emit(account_name signer) {
+        return push(N(emit), signer, args());
+    }
+
+    action_result start(account_name signer) {
+        return push(N(start), signer, args());
+    }
+    action_result start(account_name owner, vector<account_name> signers) {
+        return push_msig(N(start), {{owner, config::active_name}}, signers, args());
+    }
+
+    action_result stop(account_name signer) {
+        return push(N(stop), signer, args());
+    }
+    action_result stop(account_name owner, vector<account_name> signers) {
+        return push_msig(N(stop), {{owner, config::active_name}}, signers, args());
+    }
+
+    //// emit tables
+    variant get_state() const {
+        return get_struct(N(state), N(state), "state");
+    }
+
+};
+
+
+}} // eosio::testing

--- a/tests/golos.emit_tests.cpp
+++ b/tests/golos.emit_tests.cpp
@@ -1,0 +1,165 @@
+#include "golos_tester.hpp"
+#include "golos.emit_test_api.hpp"
+#include "golos.ctrl_test_api.hpp"
+#include "golos.vesting_test_api.hpp"
+#include "eosio.token_test_api.hpp"
+#include "contracts.hpp"
+#include "../golos.emit/include/golos.emit/config.hpp"
+
+
+namespace cfg = golos::config;
+using namespace eosio::testing;
+using namespace eosio::chain;
+using namespace fc;
+
+using symbol_type = symbol;
+
+static const auto _token = symbol_type(6,"TST");
+
+class golos_emit_tester : public golos_tester {
+protected:
+    golos_emit_api emit;
+    golos_ctrl_api ctrl;
+    golos_vesting_api vest;
+    eosio_token_api token;
+
+public:
+    golos_emit_tester()
+        : golos_tester(cfg::emission_name, _token.value())
+        , emit({this, _code, _token})
+        , ctrl({this, cfg::control_name, _token})
+        , vest({this, cfg::vesting_name})
+        , token({this, cfg::token_name})
+    {
+        vest._symbol =
+        token._symbol = _token;
+
+        create_accounts({_code, BLOG, N(witn1), N(witn2), N(witn3), N(witn4), N(witn5), _alice, _bob, _carol,
+            cfg::control_name, cfg::vesting_name, cfg::token_name, cfg::workers_name});
+        produce_block();
+
+        install_contract(_code, contracts::emit_wasm(), contracts::emit_abi());
+        install_contract(cfg::control_name, contracts::ctrl_wasm(), contracts::ctrl_abi());
+        install_contract(cfg::vesting_name, contracts::vesting_wasm(), contracts::vesting_abi());
+        install_contract(cfg::token_name, contracts::token_wasm(), contracts::token_abi());
+    }
+
+
+    asset dasset(double val = 0) const {
+        return vest.make_asset(val);
+    }
+
+    // constants
+    const uint16_t _max_witnesses = 2;
+    const uint16_t _smajor_witn_count = _max_witnesses * 2 / 3 + 1;
+
+    const account_name BLOG = N(blog);
+    const account_name _alice = N(alice);
+    const account_name _bob = N(bob);
+    const account_name _carol = N(carol);
+    const uint64_t _w[5] = {N(witn1), N(witn2), N(witn3), N(witn4), N(witn5)};
+    const size_t _n_w = sizeof(_w) / sizeof(_w[0]);
+
+    vector<account_name> witness_vect(size_t n) const {
+        vector<account_name> r;
+        auto l = std::min(n, _n_w);
+        r.reserve(l);
+        while (l--) {
+            r.push_back(_w[l]);
+        }
+        return r;
+    }
+
+    struct errors: contract_error_messages {
+        // const string no_symbol          = amsg("symbol not found");
+    } err;
+
+    const string _test_key = string(fc::crypto::config::public_key_legacy_prefix)
+        + "6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV";
+
+    // prepare; TODO: reuse ctrl code
+    enum prep_step {
+        step_0,
+        step_only_create,
+        step_reg_witnesses,
+        step_vote_witnesses
+    };
+
+    void prepare_ctrl(prep_step state) {
+        if (state == step_0) return;
+        BOOST_CHECK_EQUAL(success(),
+            ctrl.create(BLOG, ctrl.default_params(_max_witnesses, 4, cfg::workers_name)));
+        produce_block();
+        ctrl.prepare_owner(BLOG);
+        produce_block();
+
+        if (state <= step_only_create) return;
+        for (int i = 0; i < _n_w; i++) {
+            BOOST_CHECK_EQUAL(success(), ctrl.reg_witness(_w[i], _test_key, "localhost"));
+        }
+        produce_block();
+
+        if (state <= step_reg_witnesses) return;
+        prepare_balances();
+        vector<std::pair<name,name>> votes = {
+            {_alice, _w[0]}, {_alice, _w[1]}, {_alice, _w[2]}, {_alice, _w[3]},
+            {_bob, _w[0]}, {_w[0], _w[0]}
+        };
+        for (const auto& v : votes) {
+            BOOST_CHECK_EQUAL(success(), ctrl.vote_witness(v.first, v.second));
+        }
+    }
+
+    void prepare_balances() {
+        BOOST_CHECK_EQUAL(success(), token.create(BLOG, dasset(100500)));
+        BOOST_CHECK_EQUAL(success(), vest.create_vesting(BLOG, _token, {_code}));
+        BOOST_CHECK_EQUAL(success(), vest.open(cfg::vesting_name, _token, cfg::vesting_name));
+        vector<std::pair<uint64_t,double>> amounts = {
+            {BLOG, 1000}, {cfg::workers_name, 0}, {_alice, 800}, {_bob, 700}, {_carol, 600},
+            {_w[0], 100}, {_w[1], 200}, {_w[2], 300}, {_w[3], 400}, {_w[4], 500}
+        };
+        for (const auto& p : amounts) {
+            auto acc = p.first;
+            auto amount = p.second;
+            BOOST_CHECK_EQUAL(success(), vest.open(acc, _token, acc));
+            if (amount > 0) {
+                BOOST_CHECK_EQUAL(success(), token.issue(BLOG, acc, dasset(amount), "issue"));
+                BOOST_CHECK_EQUAL(success(), token.transfer(acc, cfg::vesting_name, dasset(amount), "buy vesting"));
+            } else {
+                BOOST_CHECK_EQUAL(success(), token.open(acc, _token, acc));
+            }
+        };
+        CHECK_MATCHING_OBJECT(vest.get_balance(BLOG), vest.make_balance(1000));
+        CHECK_MATCHING_OBJECT(vest.get_balance(_alice), vest.make_balance(800));
+        CHECK_MATCHING_OBJECT(vest.get_balance(cfg::workers_name), vest.make_balance(0));
+    }
+};
+
+
+BOOST_AUTO_TEST_SUITE(golos_emit_tests)
+
+BOOST_FIXTURE_TEST_CASE(start_emission_test, golos_emit_tester) try {
+    BOOST_TEST_MESSAGE("Test emission start");
+
+    BOOST_TEST_MESSAGE("--- prepare control");
+    prepare_ctrl(step_vote_witnesses);
+    produce_blocks(10);
+
+    BOOST_TEST_MESSAGE("--- start succeed");
+    auto w = witness_vect(_smajor_witn_count);
+    BOOST_CHECK_EQUAL(success(), emit.start(BLOG, w));
+    BOOST_TEST_MESSAGE("--- started");
+    auto t = emit.get_state();
+    auto tx = t["tx_id"];
+
+    BOOST_TEST_MESSAGE("--- go to block just before emission");
+    auto emit_interval = cfg::emit_interval * 1000 / cfg::block_interval_ms;
+    produce_blocks(emit_interval - 1);
+    BOOST_CHECK_EQUAL(tx, emit.get_state()["tx_id"]);
+    BOOST_TEST_MESSAGE("--- next block, check emission");
+    produce_block();
+    BOOST_CHECK_NE(tx, emit.get_state()["tx_id"]);
+
+} FC_LOG_AND_RETHROW()
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
1. added emission test (base) + testing api
2. ctrl/emit/vesting tests updated to use contracts' config (restore broken in #162)
3. removed `publication_name` from config, it's not system contract, added `workers_name`
4. ctrl: fixed inflation narrowing default value (3 sec block), some clean up
5. added `open` action to token api helper