### PR TITLE
Update posting tests to use chaindb #182

### DIFF
--- a/golos.publication/config.hpp
+++ b/golos.publication/config.hpp
@@ -2,12 +2,12 @@
 #include <common/config.hpp>
 
 namespace golos { namespace config {
-#define VOTE_OPERATION_INTERVAL 3 //sec
+const auto VOTE_OPERATION_INTERVAL = 3; //sec
+const auto MAX_REVOTES = 5;
 
 // closing post params
-#define CLOSE_MESSAGE_PERIOD 50 // 7*24*60*60
-#define UPVOTE_DISABLE_PERIOD 5 // 60*60
-#define MAX_REVOTES 5
+const auto CLOSE_MESSAGE_PERIOD = 120; // 7*24*60*60
+const auto UPVOTE_DISABLE_PERIOD = 6; // 60*60
 
 constexpr size_t CHECK_MONOTONIC_STEPS = 10;
 constexpr int64_t ONE_HUNDRED_PERCENT = 10000;
@@ -24,4 +24,3 @@ namespace limit_restorer_domain {//TODO: it will look better in a rule settings
 }
 
 }}
-

--- a/tests/golos.posting_test_api.hpp
+++ b/tests/golos.posting_test_api.hpp
@@ -61,6 +61,33 @@ struct golos_posting_api: base_contract_api {
         );
     }
 
+    action_result update_msg(
+        account_name author,
+        std::string permlink,
+        std::string title,
+        std::string body,
+        std::string language,
+        std::vector<tags> tags,
+        std::string json_metadata
+    ) {
+        return push(N(updatemssg), author, args()
+            ("account", author)
+            ("permlink", permlink)
+            ("headermssg", title)
+            ("bodymssg", body)
+            ("languagemssg", language)
+            ("tags",tags)
+            ("jsonmetadata", json_metadata)
+        );
+    }
+
+    action_result delete_msg(account_name author, std::string permlink) {
+        return push(N(deletemssg), author, args()
+            ("account", author)
+            ("permlink", permlink)
+        );
+    }
+
     action_result upvote(account_name voter, account_name author, std::string permlink, int32_t weight) {
         return vote(voter, author, permlink, weight);
     }
@@ -72,7 +99,7 @@ struct golos_posting_api: base_contract_api {
     }
 
     action_result vote(account_name voter, account_name author, std::string permlink, int32_t weight) {
-        BOOST_REQUIRE_MESSAGE(weight > -65536 && weight < 65536,
+        BOOST_REQUIRE_MESSAGE(weight >= -32768 && weight < 32768,
             "Test is broken, action cannot be serialized with such weight");
         auto act = N(upvote);
         uint16_t w = weight;
@@ -91,6 +118,18 @@ struct golos_posting_api: base_contract_api {
     }
 
     //// posting tables
+    variant get_message(account_name acc, uint64_t id) {
+        return _tester->get_chaindb_struct(_code, acc, N(messagetable), id, "message");
+    }
+
+    variant get_content(account_name acc, uint64_t id) {
+        return _tester->get_chaindb_struct(_code, acc, N(contenttable), id, "content");
+    }
+
+    variant get_vote(account_name acc, uint64_t id) {
+        return _tester->get_chaindb_struct(_code, acc, N(votetable), id, "voteinfo");
+    }
+
     std::vector<variant> get_reward_pools() {
         return _tester->get_all_chaindb_rows(_code, _code, N(rewardpools), false);
     }

--- a/tests/golos.publication_rewards_tests.cpp
+++ b/tests/golos.publication_rewards_tests.cpp
@@ -15,7 +15,7 @@ using namespace fixed_point_utils;
 using namespace eosio::testing;
 using mvo = fc::mutable_variant_object;
 
-#define PRECESION 0             // why 0?
+#define PRECESION 0
 #define TOKEN_NAME "GOLOS"
 constexpr int64_t MAXTOKENPROB = 5000;
 constexpr auto MAX_ARG = static_cast<double>(std::numeric_limits<fixp_t>::max());
@@ -62,7 +62,6 @@ protected:
     state _state;
 
     struct errors: contract_error_messages {
-        // const string no_symbol          = amsg("symbol not found");
         const string not_positive       = amsg("check positive failed for time penalty func");
         const string not_monotonic      = amsg("check monotonic failed for time penalty func");
         const string fp_cast_overflow   = amsg("fp_cast: overflow");
@@ -108,20 +107,19 @@ public:
         , _forum_name(_code)
         , _issuer(N(issuer.acc))
         , _users{
-                N(alice),  N(alice1),  N(alice2), N(alice3), N(alice4), N(alice5),
-                N(bob), N(bob1), N(bob2), N(bob3), N(bob4), N(bob5),
-                N(why), N(has), N(my), N(imagination), N(become), N(poor)}
+            N(alice),  N(alice1),  N(alice2), N(alice3), N(alice4), N(alice5),
+            N(bob), N(bob1), N(bob2), N(bob3), N(bob4), N(bob5),
+            N(why), N(has), N(my), N(imagination), N(become), N(poor)}
         , _stranger(N(dan.larimer)) {
 
         step(2);
-        create_accounts({_forum_name, _issuer, cfg::vesting_name, cfg::token_name, cfg::control_name, _stranger});
+        create_accounts({_forum_name, _issuer, cfg::vesting_name, cfg::token_name, _stranger});
         create_accounts(_users);
         step(2);
 
         install_contract(_forum_name, contracts::posting_wasm(), contracts::posting_abi());
         install_contract(cfg::token_name, contracts::token_wasm(), contracts::token_abi());
         install_contract(cfg::vesting_name, contracts::vesting_wasm(), contracts::vesting_abi());
-        // install_contract(cfg::control_name, contracts::ctrl_wasm(), contracts::ctrl_abi());
     }
 
     action_result add_funds_to(account_name user, int64_t amount) {
@@ -171,10 +169,6 @@ public:
             fill_depleted_pool(amount, _state.pools.size());
         }
         return ret;
-    }
-
-    action_result push_action(const account_name& signer, const action_name& name, const variant_object& data, const account_name& code) {
-        return golos_tester::push_action(code, name, signer, data);
     }
 
     action_result setrules(
@@ -330,7 +324,7 @@ public:
         for (auto itr_p = _state.pools.begin(); itr_p != _state.pools.end(); itr_p++) {
             auto& p = *itr_p;
             for (auto itr_m = p.messages.begin(); itr_m != p.messages.end();) {
-                if ((cur_time().to_seconds() - itr_m->created) > CLOSE_MESSAGE_PERIOD) {
+                if ((cur_time().to_seconds() - itr_m->created) > cfg::CLOSE_MESSAGE_PERIOD) {
                     auto m = *itr_m;
                     double pool_rsharesfn_sum = p.get_rsharesfn_sum();
 

--- a/tests/golos.publication_rewards_types.hpp
+++ b/tests/golos.publication_rewards_types.hpp
@@ -43,7 +43,7 @@ constexpr double pool_rshares_delta = 0.01;
 constexpr double pool_rsharesfn_delta = 0.01;
 
 
-double get_prop(int64_t arg) {
+inline double get_prop(int64_t arg) {
     return static_cast<double>(arg) / static_cast<double>(golos::config::_100percent);
 }
 
@@ -78,7 +78,7 @@ struct aprox_val_t {
     aprox_val_t& operator +=(const double& arg) { val += arg; return *this; }
 };
 
-std::ostream& operator<< (std::ostream& os, const aprox_val_t& rhs) {
+inline std::ostream& operator<< (std::ostream& os, const aprox_val_t& rhs) {
     os << std::to_string(rhs.val) << " (" << std::to_string(double(rhs.delta)) << ") ";
     return os;
 }
@@ -148,12 +148,11 @@ struct statemap : public std::map<std::string, aprox_val_t> {
     }
 };
 
-std::ostream& operator<< (std::ostream& os, const statemap& rhs) {
+inline std::ostream& operator<< (std::ostream& os, const statemap& rhs) {
     for (auto itr = rhs.begin(); itr != rhs.end(); ++itr)
         os << itr->first << " = " << itr->second << "\n";
     return os;
 }
-
 
 
 struct vote {

--- a/tests/golos.publication_tests.cpp
+++ b/tests/golos.publication_tests.cpp
@@ -1,28 +1,20 @@
 #define UNIT_TEST_ENV
-#include <boost/test/unit_test.hpp>
-#include <boost/algorithm/string/predicate.hpp>
-#include <eosio/chain/abi_serializer.hpp>
-
-#include <Runtime/Runtime.h>
-#include <fc/variant_object.hpp>
-#include <eosio/testing/tester.hpp>
-
 #include "golos_tester.hpp"
-#include "contracts.hpp"
-
+#include "golos.posting_test_api.hpp"
+#include "golos.vesting_test_api.hpp"
+#include "eosio.token_test_api.hpp"
 #include "../golos.publication/types.h"
 #include "../golos.publication/config.hpp"
+#include "contracts.hpp"
+
+
 using namespace fixed_point_utils;
-
-#define UNLOCKED_FOR_CREATE_MESSAGE 21
-
-using namespace eosio;
 using namespace eosio::chain;
 using namespace eosio::testing;
 using namespace fc;
-using namespace golos::config;
-
 using mvo = fc::mutable_variant_object;
+namespace cfg = golos::config;
+
 
 namespace structures {
     struct beneficiaries {
@@ -39,715 +31,342 @@ FC_REFLECT(structures::beneficiaries, (account)(deductprcnt))
 
 
 class golos_publication_tester : public golos_tester {
+protected:
+    symbol _sym;
+    golos_posting_api post;
+    golos_vesting_api vest;
+    eosio_token_api token;
+
     std::vector<account_name> _users;
 public:
 
-    golos_publication_tester(): _users{N(jackiechan), N(brucelee), N(chucknorris), N(golos.pub)} {
-        produce_blocks(2);
+    golos_publication_tester()
+        : golos_tester(N(golos.pub))
+        , _sym(0, "DUMMY")
+        , post({this, _code, _sym})
+        , vest({this, cfg::vesting_name, _sym})
+        , token({this, cfg::token_name, _sym})
+        , _users{_code, N(jackiechan), N(brucelee), N(chucknorris)} {
+
+        produce_block();
         create_accounts(_users);
-        create_accounts({N(eosio.token)});
-        create_accounts({vesting_name});
-        create_accounts({N(dan.larimer)});
+        create_accounts({cfg::token_name, cfg::vesting_name, N(dan.larimer)});
+        produce_block();
 
-        produce_blocks(2);
-
-        install_contract(N(golos.pub), contracts::posting_wasm(), contracts::posting_abi());
-        install_contract(N(eosio.token), contracts::token_wasm(), contracts::token_abi());
-        install_contract(vesting_name, contracts::vesting_wasm(), contracts::vesting_abi());
-    }
-
-    action_result push_action(const account_name& signer,
-                              const action_name &name,
-                              const variant_object &data, const account_name& code = N(golos.pub)) {
-       auto& abi_ser = _abis[code];
-       string action_type_name = abi_ser.get_action_type(name);
-       action act;
-       act.account = code;
-       act.name = name;
-       act.data = abi_ser.variant_to_binary(action_type_name, data, abi_serializer_max_time);
-
-       return base_tester::push_action(std::move(act), uint64_t(signer));
+        install_contract(_code, contracts::posting_wasm(), contracts::posting_abi());
+        install_contract(cfg::vesting_name, contracts::vesting_wasm(), contracts::vesting_abi());
+        install_contract(cfg::token_name, contracts::token_wasm(), contracts::token_abi());
     }
 
     void init() {
-        symbol sym(0, "DUMMY");
-        BOOST_REQUIRE_EQUAL(success(), push_action(N(golos.pub), N(open),
-            mvo()( "owner", account_name(N(golos.pub)))
-            ( "symbol", sym)
-            ( "ram_payer", account_name(N(golos.pub))),
-            N(eosio.token)));
-
-        limitsarg lims = {{"0"}, {{0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}}, {0, 0}, {0, 0, 0}};
-        BOOST_REQUIRE_EQUAL(success(), push_action(N(golos.pub), N(setrules), mvo()
-                ("mainfunc", mvo()("str", "0")("maxarg", 1))
-                ("curationfunc", mvo()("str", "0")("maxarg", 1))
-                ("timepenalty", mvo()("str", "0")("maxarg", 1))
-                ("curatorsprop", 0)
-                ("maxtokenprop", 0)
-                ("tokensymbol", sym)
-                ("lims", lims)));
-        for(auto& u : _users) {
-            BOOST_REQUIRE_EQUAL(success(), push_action( u, N(open),
-                mvo()( "owner", u)
-                ( "symbol", sym)
-                ( "ram_payer", u),
-                vesting_name));
+        BOOST_CHECK_EQUAL(success(), token.open(_code, _sym, _code));
+        funcparams fn{"0", 1};
+        BOOST_CHECK_EQUAL(success(), post.set_rules(fn ,fn ,fn , 0, 0));
+        for (auto& u : _users) {
+            BOOST_CHECK_EQUAL(success(), vest.open(u, _sym, u));
         }
     }
 
-    action_result create_message(account_name account, std::string permlink,
-                              account_name parentacc = N(), std::string parentprmlnk = "parentprmlnk",
-                              std::vector<structures::beneficiaries> beneficiaries = {{N(golos.pub), 777}},
-                              int64_t tokenprop = 5000, bool vestpayment = false,
-                              std::string headermssg = "headermssg",
-                              std::string bodymssg = "bodymssg", std::string languagemssg = "languagemssg",
-                              std::vector<structures::tags> tags = {{"tag"}},
-                              std::string jsonmetadata = "jsonmetadata") {
-        return push_action(account, N(createmssg), mvo()
-                           ("account", account)
-                           ("permlink", permlink)
-                           ("parentacc", parentacc)
-                           ("parentprmlnk", parentprmlnk)
-                           ("beneficiaries", beneficiaries)
-                           ("tokenprop", tokenprop)
-                           ("vestpayment", vestpayment)
-                           ("headermssg", headermssg)
-                           ("bodymssg", bodymssg)
-                           ("languagemssg", languagemssg)
-                           ("tags", tags)
-                           ("jsonmetadata", jsonmetadata)
-        );
+    void check_equal_post(const variant& a, const variant& b) {
+        BOOST_CHECK_EQUAL(true, a.is_object() && b.is_object());
+        BOOST_CHECK_EQUAL(a["id"].as<uint64_t>(), b["id"].as<uint64_t>());
+        BOOST_CHECK_EQUAL(a["date"].as<uint64_t>(), b["date"].as<uint64_t>());
+        BOOST_CHECK_EQUAL(a["parentacc"].as<account_name>(), b["parentacc"].as<account_name>());
+        BOOST_CHECK_EQUAL(a["parent_id"].as<uint64_t>(), b["parent_id"].as<uint64_t>());
+        BOOST_CHECK_EQUAL(a["tokenprop"].as<uint64_t>(), b["tokenprop"].as<uint64_t>());
+        auto a_ben = a["beneficiaries"];
+        auto b_ben = b["beneficiaries"];
+        BOOST_CHECK_EQUAL(a_ben.size(), b_ben.size());
+        for (size_t i = 0, l = a_ben.size(); i < l; i++) {
+            CHECK_EQUAL_OBJECTS(a_ben[i], b_ben[i]);
+        }
+        BOOST_CHECK_EQUAL(a["rewardweight"].as<uint64_t>(), b["rewardweight"].as<uint64_t>());
+        CHECK_EQUAL_OBJECTS(a["state"], b["state"]);
+        BOOST_CHECK_EQUAL(a["childcount"].as<uint64_t>(), b["childcount"].as<uint64_t>());
+        BOOST_CHECK_EQUAL(a["closed"].as<bool>(), b["closed"].as<bool>());
+        BOOST_CHECK_EQUAL(a["level"].as<uint16_t>(), b["level"].as<uint16_t>());
     }
 
-    fc::variant get_messages( account_name acc, uint64_t id ) {
-        return get_tbl_struct(N(golos.pub), acc, N(messagetable), id, "message");
+    void check_equal_content(const variant& a, const variant& b) {
+        BOOST_CHECK_EQUAL(true, a.is_object() && b.is_object());
+        BOOST_CHECK_EQUAL(a["id"].as<uint64_t>(), b["id"].as<uint64_t>());
+        BOOST_CHECK_EQUAL(a["headermssg"].as<std::string>(), b["headermssg"].as<std::string>());
+        BOOST_CHECK_EQUAL(a["bodymssg"].as<std::string>(), b["bodymssg"].as<std::string>());
+        BOOST_CHECK_EQUAL(a["languagemssg"].as<std::string>(), b["languagemssg"].as<std::string>());
+        auto a_tags = a["tags"];
+        auto b_tags = b["tags"];
+        BOOST_CHECK_EQUAL(a_tags.size(), b_tags.size());
+        for (size_t i = 0, l = a_tags.size(); i < l; i++) {
+            CHECK_EQUAL_OBJECTS(a_tags[i], b_tags[i]);
+        }
+        BOOST_CHECK_EQUAL(a["jsonmetadata"].as<std::string>(), b["jsonmetadata"].as<std::string>());
     }
 
-    fc::variant get_content( account_name acc, uint64_t id ) {
-        return get_tbl_struct(N(golos.pub), acc, N(contenttable), id, "content");
-    }
+protected:
+    const mvo _test_msg = mvo()
+        ("id", hash64("permlink"))
+        ("date", 1577836836000000ull)
+        ("parentacc", "")
+        ("parent_id", 0)
+        ("tokenprop", 0)
+        ("beneficiaries", variants({}
+            // mvo()
+            // ("account", "golos.pub")
+            // ("deductprcnt", static_cast<base_t>(elaf_t(elai_t(777) / elai_t(10000)).data()))}
+        ))
+        ("rewardweight", 4611686018427387904ull)    // TODO: fix
+        ("state", mvo()("absshares",0)("netshares",0)("voteshares",0)("sumcuratorsw",0))
+        ("childcount", 0)
+        ("closed", false)
+        ("level", 0);
 
-    fc::variant get_vote( account_name acc, uint64_t id ) {
-        return get_tbl_struct(N(golos.pub), acc, N(votetable), id, "voteinfo");
-    }
+    const mvo _test_content = mvo()
+        ("id", hash64("permlink"))
+        ("headermssg", "headermssg")
+        ("bodymssg", "bodymssg")
+        ("languagemssg", "languagemssg")
+        ("tags", variants({mvo()("tag", "tag")}))
+        ("jsonmetadata", "jsonmetadata");
 
-    action_result update_message(account_name account, std::string permlink,
-                              std::string headermssg, std::string bodymssg,
-                              std::string languagemssg, std::vector<structures::tags> tags,
-                              std::string jsonmetadata) {
-        return push_action(account, N(updatemssg), mvo()
-                           ("account", account)
-                           ("permlink", permlink)
-                           ("headermssg", headermssg)
-                           ("bodymssg", bodymssg)
-                           ("languagemssg", languagemssg)
-                           ("tags",tags)
-                           ("jsonmetadata", jsonmetadata)
-        );
-    }
+    struct errors: contract_error_messages {
+        const string msg_exists         = amsg("This message already exists.");
+        const string unregistered_user_ = amsg("unregistered user: ");
+        const string no_content         = amsg("Content doesn't exist.");
 
-    action_result delete_message(account_name account, std::string permlink) {
-        return push_action(account, N(deletemssg), mvo()
-                           ("account", account)
-                           ("permlink", permlink)
-        );
-    }
-
-    action_result upvote(account_name voter, account_name author, std::string permlink, int16_t weight) {
-        return push_action(voter, N(upvote), mvo()
-                           ("voter", voter)
-                           ("author", author)
-                           ("permlink", permlink)
-                           ("weight", weight)
-        );
-    }
-
-    action_result downvote(account_name voter, account_name author, std::string permlink, int16_t weight) {
-        return push_action(voter, N(downvote), mvo()
-                           ("voter", voter)
-                           ("author", author)
-                           ("permlink", permlink)
-                           ("weight", weight)
-        );
-    }
-
-    action_result unvote(account_name voter, account_name author, std::string permlink) {
-        return push_action(voter, N(unvote), mvo()
-                           ("voter", voter)
-                           ("author", author)
-                           ("permlink", permlink)
-        );
-    }
-
-    void check_equal(const fc::variant &obj1, const fc::variant &obj2) {
-        BOOST_CHECK_EQUAL(true, obj1.is_object() && obj2.is_object());
-        BOOST_CHECK_EQUAL(obj1.get_object()["id"].as<uint64_t>(), obj2.get_object()["id"].as<uint64_t>());
-        BOOST_CHECK_EQUAL(obj1.get_object()["parentacc"].as<account_name>(), obj2.get_object()["parentacc"].as<account_name>());
-        BOOST_CHECK_EQUAL(obj1.get_object()["parent_id"].as<uint64_t>(), obj2.get_object()["parent_id"].as<uint64_t>());
-        BOOST_CHECK_EQUAL(obj1.get_object()["beneficiaries"].get_array().at(0).get_object()["account"].as<account_name>(), obj2.get_object()["beneficiaries"].get_array().at(0).get_object()["account"].as<account_name>());
-        BOOST_CHECK_EQUAL(obj1.get_object()["beneficiaries"].get_array().at(0).get_object()["deductprcnt"].as<uint64_t>(), obj2.get_object()["beneficiaries"].get_array().at(0).get_object()["deductprcnt"].as<uint64_t>());
-        BOOST_CHECK_EQUAL(obj1.get_object()["childcount"].as<uint64_t>(), obj2.get_object()["childcount"].as<uint64_t>());
-        BOOST_CHECK_EQUAL(obj1.get_object()["closed"].as<bool>(), obj2.get_object()["closed"].as<bool>());
-    }
-
-    void check_equal_content(const fc::variant &obj1, const fc::variant &obj2) {
-        BOOST_CHECK_EQUAL(true, obj1.is_object() && obj2.is_object());
-        BOOST_CHECK_EQUAL(obj1.get_object()["id"].as<uint64_t>(), obj2.get_object()["id"].as<uint64_t>());
-        BOOST_CHECK_EQUAL(obj1.get_object()["headermssg"].as<std::string>(), obj2.get_object()["headermssg"].as<std::string>());
-        BOOST_CHECK_EQUAL(obj1.get_object()["bodymssg"].as<std::string>(), obj2.get_object()["bodymssg"].as<std::string>());
-        BOOST_CHECK_EQUAL(obj1.get_object()["languagemssg"].as<std::string>(), obj2.get_object()["languagemssg"].as<std::string>());
-        BOOST_CHECK_EQUAL(obj1.get_object()["tags"].get_array().at(0).get_object()["tag"].as_string(), obj2.get_object()["tags"].get_array().at(0).get_object()["tag"].as_string());
-        BOOST_CHECK_EQUAL(obj1.get_object()["jsonmetadata"].as<std::string>(), obj2.get_object()["jsonmetadata"].as<std::string>());
-    }
-
+        const string delete_children    = amsg("You can't delete comment with child comments.");
+        const string no_message         = amsg("Message doesn't exist.");
+        const string vote_same_weight   = amsg("Vote with the same weight has already existed.");
+        const string vote_weight_le0    = amsg("The weight must be positive.");
+        const string vote_weight_gt100  = amsg("The weight can't be more than 100%.");
+        const string no_revote          = amsg("You can't revote anymore.");
+        const string upvote_near_close  = amsg("You can't upvote, because publication will be closed soon.");
+        const string vote_weight_sign   = amsg("The weight sign can't be negative.");
+        const string max_comment_depth  = amsg("publication::create_message: level > MAX_COMMENT_DEPTH");
+    } err;
 };
+
 
 BOOST_AUTO_TEST_SUITE(golos_publication_tests)
 
 BOOST_FIXTURE_TEST_CASE(create_message, golos_publication_tester) try {
     BOOST_TEST_MESSAGE("Create message testing.");
     init();
-    BOOST_CHECK_EQUAL(success(), golos_publication_tester::create_message(
-                            N(brucelee),
-                            "permlink"));
+    BOOST_CHECK_EQUAL(success(), post.create_msg(N(brucelee), "permlink"));
 
     BOOST_TEST_MESSAGE("Checking that another user can create a message with the same permlink.");
-    BOOST_CHECK_EQUAL(success(), golos_publication_tester::create_message(
-                            N(chucknorris),
-                            "permlink"));
+    BOOST_CHECK_EQUAL(success(), post.create_msg(N(chucknorris), "permlink"));
 
-    auto mssg_stats = get_messages(N(brucelee), 0);
-    check_equal( mssg_stats, mvo()
-                   ("id", hash64("permlink"))
-                   ("date", 1577836804)
-                   ("parentacc", "")
-                   ("parent_id", 0)
-                   ("beneficiaries", variants({
-                                                  mvo()
-                                                  ("account", "golos.pub")
-                                                  ("deductprcnt", static_cast<base_t>(elaf_t(elai_t(777) / elai_t(10000)).data()))
-                                              }))
-                   ("childcount", 0)
-                   ("closed", false)
-                   );
+    auto id = hash64("permlink");
+    check_equal_post(post.get_message(N(brucelee), id), _test_msg);
+    check_equal_content(post.get_content(N(brucelee), id), _test_content);
 
-    auto content_stats = get_content(N(brucelee), hash64("permlink"));
-    check_equal_content(content_stats, mvo()
-                            ("id", hash64("permlink"))
-                            ("headermssg", "headermssg")
-                            ("bodymssg", "bodymssg")
-                            ("languagemssg", "languagemssg")
-                            ("tags", variants({
-                                                  mvo()
-                                                  ("tag", "tag")
-                                              }))
-                            ("jsonmetadata", "jsonmetadata"));
+    BOOST_TEST_MESSAGE("Checking that message wasn't closed.");
+    produce_blocks(cfg::CLOSE_MESSAGE_PERIOD*2-2);   // TODO: time to blocks
+    auto msg = post.get_message(N(brucelee), id);
+    BOOST_CHECK_EQUAL(msg["closed"].as<bool>(), false);
 
-    produce_blocks(CLOSE_MESSAGE_PERIOD*2-2);
+    BOOST_TEST_MESSAGE("Checking that message was closed.");
+    produce_block();
+    msg = post.get_message(N(brucelee), id);
+    BOOST_CHECK_EQUAL(msg["closed"].as<bool>(), true);
 
-    {
-        BOOST_TEST_MESSAGE("Checking that message wasn't closed.");
-        auto mssg_stats = get_messages(N(brucelee), hash64("permlink"));
-        BOOST_CHECK_EQUAL(fc::variant(mssg_stats).get_object()["closed"].as<bool>(), false);
-    }
+    BOOST_CHECK_EQUAL(success(), post.create_msg(N(jackiechan), "permlink1", N(brucelee), "permlink"));
+    msg = post.get_message(N(brucelee), id);
+    BOOST_CHECK_EQUAL(msg["childcount"].as<uint64_t>(), 1);
 
-    {
-        BOOST_TEST_MESSAGE("Checking that message was closed.");
-        produce_blocks(1);
-        auto mssg_stats = get_messages(N(brucelee), hash64("permlink"));
-        BOOST_CHECK_EQUAL(fc::variant(mssg_stats).get_object()["closed"].as<bool>(), true);
-    }
-
-    {
-        BOOST_CHECK_EQUAL(success(), golos_publication_tester::create_message(
-                                N(jackiechan),
-                                "permlink1",
-                                N(brucelee),
-                                "permlink"));
-
-        auto mssg_stats = get_messages(N(brucelee), 0);
-        BOOST_CHECK_EQUAL(fc::variant(mssg_stats).get_object()["childcount"].as<uint64_t>(), 1);
-    }
-
-    BOOST_CHECK_EQUAL(error("assertion failure with message: This message already exists."), golos_publication_tester::create_message(
-                            N(brucelee),
-                            "permlink"));
-    BOOST_CHECK_EQUAL(error("assertion failure with message: unregistered user: dan.larimer"), golos_publication_tester::create_message(
-                            N(dan.larimer),
-                            "Hi"));
-
+    BOOST_CHECK_EQUAL(err.msg_exists, post.create_msg(N(brucelee), "permlink"));
+    BOOST_CHECK_EQUAL(err.unregistered_user_ + "dan.larimer", post.create_msg(N(dan.larimer), "Hi"));
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE(update_message, golos_publication_tester) try {
     BOOST_TEST_MESSAGE("Update message testing.");
     init();
 
-    BOOST_CHECK_EQUAL(success(), golos_publication_tester::create_message(
-                            N(brucelee),
-                            "permlink"));
+    BOOST_CHECK_EQUAL(success(), post.create_msg(N(brucelee), "permlink"));
+    BOOST_CHECK_EQUAL(success(), post.update_msg(N(brucelee), "permlink",
+        "headermssgnew", "bodymssgnew", "languagemssgnew", {{"tagnew"}}, "jsonmetadatanew"));
 
-    BOOST_CHECK_EQUAL(success(), golos_publication_tester::update_message(
-                            N(brucelee),
-                            "permlink",
-                            "headermssgnew",
-                            "bodymssgnew",
-                            "languagemssgnew",
-                            {{"tagnew"}},
-                            "jsonmetadatanew"));
-
-    auto content_stats = get_content(N(brucelee), hash64("permlink"));
-    check_equal_content(content_stats, mvo()
-                            ("id", hash64("permlink"))
-                            ("headermssg", "headermssgnew")
-                            ("bodymssg", "bodymssgnew")
-                            ("languagemssg", "languagemssgnew")
-                            ("tags", variants({
-                                                  mvo()
-                                                  ("tag", "tagnew")
-                                              }))
-                            ("jsonmetadata", "jsonmetadatanew"));
-
-    BOOST_CHECK_EQUAL(error("assertion failure with message: Content doesn't exist."), golos_publication_tester::update_message(
-                            N(brucelee),
-                            "permlinknew",
-                            "headermssgnew",
-                            "bodymssgnew",
-                            "languagemssgnew",
-                            {{"tagnew"}},
-                            "jsonmetadatanew"));
+    check_equal_content(post.get_content(N(brucelee), hash64("permlink")), mvo()
+        ("id", hash64("permlink"))
+        ("headermssg", "headermssgnew")
+        ("bodymssg", "bodymssgnew")
+        ("languagemssg", "languagemssgnew")
+        ("tags", variants({mvo()("tag", "tagnew")}))
+        ("jsonmetadata", "jsonmetadatanew"));
+    BOOST_CHECK_EQUAL(err.no_content, post.update_msg(N(brucelee), "permlinknew",
+        "headermssgnew", "bodymssgnew", "languagemssgnew", {{"tagnew"}}, "jsonmetadatanew"));
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE(delete_message, golos_publication_tester) try {
     BOOST_TEST_MESSAGE("Delete message testing.");
     init();
 
-    BOOST_CHECK_EQUAL(success(), golos_publication_tester::create_message(
-                            N(brucelee),
-                            "permlink"));
+    BOOST_CHECK_EQUAL(success(), post.create_msg(N(brucelee), "permlink"));
+    BOOST_CHECK_EQUAL(success(), post.create_msg(N(jackiechan), "child", N(brucelee), "permlink"));
 
-    BOOST_CHECK_EQUAL(success(), golos_publication_tester::create_message(
-                            N(jackiechan),
-                            "permlink1",
-                            N(brucelee),
-                            "permlink"));
+    BOOST_TEST_MESSAGE("--- fail then delete non-existing post and post with child");
+    BOOST_CHECK_EQUAL(err.no_message, post.delete_msg(N(jackiechan), "permlink1"));
+    BOOST_CHECK_EQUAL(err.delete_children, post.delete_msg(N(brucelee), "permlink"));
 
-    BOOST_CHECK_EQUAL(error("assertion failure with message: You can't delete comment with child comments."), golos_publication_tester::delete_message(
-                            N(brucelee),
-                            "permlink"));
-
-    BOOST_CHECK_EQUAL(success(), golos_publication_tester::delete_message(
-                            N(jackiechan),
-                            "permlink1"));
-
-    BOOST_CHECK_EQUAL(error("assertion failure with message: Message doesn't exist."), golos_publication_tester::delete_message(
-                            N(jackiechan),
-                            "permlink1"));
-
-    BOOST_CHECK_EQUAL(success(), golos_publication_tester::delete_message(
-                            N(brucelee),
-                            "permlink"));
+    BOOST_TEST_MESSAGE("--- success when delete child");
+    BOOST_CHECK_EQUAL(success(), post.delete_msg(N(jackiechan), "child"));
+    BOOST_TEST_MESSAGE("--- success delete when no more children");
+    BOOST_CHECK_EQUAL(success(), post.delete_msg(N(brucelee), "permlink"));
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE(upvote, golos_publication_tester) try {
     BOOST_TEST_MESSAGE("Upvote testing.");
     init();
 
-    BOOST_CHECK_EQUAL(success(), golos_publication_tester::create_message(
-                            N(brucelee),
-                            "permlink"));
+    BOOST_CHECK_EQUAL(success(), post.create_msg(N(brucelee), "permlink"));
+    BOOST_CHECK_EQUAL(success(), post.upvote(N(brucelee), N(brucelee), "permlink", 123));
+    produce_blocks(cfg::VOTE_OPERATION_INTERVAL*2);
+    BOOST_CHECK_EQUAL(err.vote_same_weight, post.upvote(N(brucelee), N(brucelee), "permlink", 123));
+    BOOST_CHECK_EQUAL(err.no_message, post.upvote(N(brucelee), N(jackiechan), "permlink", 111));
+    BOOST_CHECK_EQUAL(err.vote_weight_le0, post.upvote(N(brucelee), N(brucelee), "permlink", -333));    // why we need int instead of uint?
+    BOOST_CHECK_EQUAL(err.vote_weight_sign, post.upvote(N(brucelee), N(brucelee), "permlink", 0));
+    BOOST_CHECK_EQUAL(success(), post.upvote(N(brucelee), N(brucelee), "permlink", cfg::_100percent));
+    produce_blocks(cfg::VOTE_OPERATION_INTERVAL*2);
+    BOOST_CHECK_EQUAL(err.vote_weight_gt100, post.upvote(N(brucelee), N(brucelee), "permlink", cfg::_100percent+1));
 
-    BOOST_CHECK_EQUAL(success(), golos_publication_tester::upvote(
-                            N(brucelee),
-                            N(brucelee),
-                            "permlink",
-                            123));
-    produce_blocks(VOTE_OPERATION_INTERVAL*2);
+    BOOST_CHECK_EQUAL(success(), post.upvote(N(jackiechan), N(brucelee), "permlink", 111));
+    produce_blocks(cfg::VOTE_OPERATION_INTERVAL*2);
+    BOOST_CHECK_EQUAL(success(), post.upvote(N(jackiechan), N(brucelee), "permlink", 222));
+    produce_blocks(cfg::VOTE_OPERATION_INTERVAL*2);
+    BOOST_CHECK_EQUAL(success(), post.upvote(N(jackiechan), N(brucelee), "permlink", 333));
+    produce_blocks(cfg::VOTE_OPERATION_INTERVAL*2);
+    BOOST_CHECK_EQUAL(success(), post.upvote(N(jackiechan), N(brucelee), "permlink", 444));
+    produce_blocks(cfg::VOTE_OPERATION_INTERVAL*2);
+    BOOST_CHECK_EQUAL(success(), post.upvote(N(jackiechan), N(brucelee), "permlink", 555));
+    produce_blocks(cfg::VOTE_OPERATION_INTERVAL*2);
 
-    BOOST_CHECK_EQUAL(error("assertion failure with message: Vote with the same weight has already existed."), golos_publication_tester::upvote(
-                            N(brucelee),
-                            N(brucelee),
-                            "permlink",
-                            123));
-    produce_blocks(VOTE_OPERATION_INTERVAL*2);
+    auto vote = post.get_vote(N(brucelee), 1);
+    BOOST_CHECK_EQUAL(vote["count"].as<int64_t>(), 5);
 
-    BOOST_CHECK_EQUAL(error("assertion failure with message: Message doesn't exist."), golos_publication_tester::upvote(
-                            N(brucelee),
-                            N(jackiechan),
-                            "permlink",
-                            111));
-    produce_blocks(VOTE_OPERATION_INTERVAL*2);
+    BOOST_CHECK_EQUAL(err.no_revote, post.upvote(N(jackiechan), N(brucelee), "permlink", 777));
+    produce_blocks(cfg::CLOSE_MESSAGE_PERIOD*2 - cfg::VOTE_OPERATION_INTERVAL*2*12-6);
 
-    BOOST_CHECK_EQUAL(error("assertion failure with message: The weight must be positive."), golos_publication_tester::upvote(
-                            N(brucelee),
-                            N(brucelee),
-                            "permlink",
-                            -333));
-    produce_blocks(VOTE_OPERATION_INTERVAL*2);
-
-    BOOST_CHECK_EQUAL(error("assertion failure with message: The weight must be positive."), golos_publication_tester::upvote(
-                            N(brucelee),
-                            N(brucelee),
-                            "permlink",
-                            0));
-    produce_blocks(VOTE_OPERATION_INTERVAL*2);
-
-    BOOST_CHECK_EQUAL(success(), golos_publication_tester::upvote(
-                            N(brucelee),
-                            N(brucelee),
-                            "permlink",
-                            10000));
-    produce_blocks(VOTE_OPERATION_INTERVAL*2);
-
-    BOOST_CHECK_EQUAL(error("assertion failure with message: The weight can't be more than 100%."), golos_publication_tester::upvote(
-                            N(brucelee),
-                            N(brucelee),
-                            "permlink",
-                            10001));
-    produce_blocks(VOTE_OPERATION_INTERVAL*2);
-
-    BOOST_CHECK_EQUAL(success(), golos_publication_tester::upvote(
-                            N(jackiechan),
-                            N(brucelee),
-                            "permlink",
-                            111));
-    produce_blocks(VOTE_OPERATION_INTERVAL*2);
-
-    BOOST_CHECK_EQUAL(success(), golos_publication_tester::upvote(
-                            N(jackiechan),
-                            N(brucelee),
-                            "permlink",
-                            222));
-    produce_blocks(VOTE_OPERATION_INTERVAL*2);
-
-    BOOST_CHECK_EQUAL(success(), golos_publication_tester::upvote(
-                            N(jackiechan),
-                            N(brucelee),
-                            "permlink",
-                            333));
-    produce_blocks(VOTE_OPERATION_INTERVAL*2);
-
-    BOOST_CHECK_EQUAL(success(), golos_publication_tester::upvote(
-                            N(jackiechan),
-                            N(brucelee),
-                            "permlink",
-                            444));
-    produce_blocks(VOTE_OPERATION_INTERVAL*2);
-
-    BOOST_CHECK_EQUAL(success(), golos_publication_tester::upvote(
-                            N(jackiechan),
-                            N(brucelee),
-                            "permlink",
-                            555));
-    produce_blocks(VOTE_OPERATION_INTERVAL*2);
-
-    auto vote_stats = get_vote(N(brucelee), 1);
-    BOOST_CHECK_EQUAL(fc::variant(vote_stats).get_object()["count"].as<int64_t>(), 5);
-
-    BOOST_CHECK_EQUAL(error("assertion failure with message: You can't revote anymore."), golos_publication_tester::upvote(
-                            N(jackiechan),
-                            N(brucelee),
-                            "permlink",
-                            777));
-    produce_blocks(CLOSE_MESSAGE_PERIOD*2 - VOTE_OPERATION_INTERVAL*2*12-6);
-
-    BOOST_CHECK_EQUAL(success(), golos_publication_tester::upvote(
-                          N(jackiechan),
-                          N(brucelee),
-                          "permlink",
-                          777));
-
-    {
-        auto vote_stats = get_vote(N(brucelee), 1);
-        BOOST_CHECK_EQUAL(fc::variant(vote_stats).get_object()["count"].as<int64_t>(), -1);
-    }
+    BOOST_CHECK_EQUAL(success(), post.upvote(N(jackiechan), N(brucelee), "permlink", 777));
+    vote = post.get_vote(N(brucelee), 1);
+    BOOST_CHECK_EQUAL(vote["count"].as<int64_t>(), -1);
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE(disable_upvote, golos_publication_tester) try {
     BOOST_TEST_MESSAGE("Disable upvote testing.");
     init();
 
-    BOOST_CHECK_EQUAL(success(), golos_publication_tester::create_message(
-                            N(brucelee),
-                            "permlink"));
-    produce_blocks((CLOSE_MESSAGE_PERIOD - UPVOTE_DISABLE_PERIOD)*2-1);
+    BOOST_CHECK_EQUAL(success(), post.create_msg(N(brucelee), "permlink"));
+    produce_blocks((cfg::CLOSE_MESSAGE_PERIOD - cfg::UPVOTE_DISABLE_PERIOD)*2-1);
 
-    BOOST_CHECK_EQUAL(success(), golos_publication_tester::upvote(
-                            N(brucelee),
-                            N(brucelee),
-                            "permlink",
-                            888));
-        produce_blocks(2);
-        BOOST_CHECK_EQUAL(error("assertion failure with message: You can't upvote, because publication will be closed soon."), golos_publication_tester::upvote(
-                                N(jackiechan),
-                                N(brucelee),
-                                "permlink",
-                                777));
-        produce_blocks(UPVOTE_DISABLE_PERIOD*2-3);
-
-        BOOST_CHECK_EQUAL(error("assertion failure with message: You can't upvote, because publication will be closed soon."), golos_publication_tester::upvote(
-                                N(brucelee),
-                                N(brucelee),
-                                "permlink",
-                                777));
-        produce_blocks(1);
-
-        BOOST_CHECK_EQUAL(success(), golos_publication_tester::upvote(
-                                N(jackiechan),
-                                N(brucelee),
-                                "permlink",
-                                888));
+    BOOST_CHECK_EQUAL(success(), post.upvote(N(brucelee), N(brucelee), "permlink", 888));
+    produce_blocks(2);
+    BOOST_CHECK_EQUAL(err.upvote_near_close, post.upvote(N(jackiechan), N(brucelee), "permlink", 777));
+    produce_blocks(cfg::UPVOTE_DISABLE_PERIOD*2-3);
+    BOOST_CHECK_EQUAL(err.upvote_near_close, post.upvote(N(brucelee), N(brucelee), "permlink", 777));
+    produce_block();
+    BOOST_CHECK_EQUAL(success(), post.upvote(N(jackiechan), N(brucelee), "permlink", 888));
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE(downvote, golos_publication_tester) try {
     BOOST_TEST_MESSAGE("Downvote testing.");
     init();
 
-    BOOST_CHECK_EQUAL(success(), golos_publication_tester::create_message(
-                            N(brucelee),
-                            "permlink"));
+    BOOST_CHECK_EQUAL(success(), post.create_msg(N(brucelee), "permlink"));
+    BOOST_CHECK_EQUAL(success(), post.downvote(N(brucelee), N(brucelee), "permlink", 123));
+    produce_blocks(cfg::VOTE_OPERATION_INTERVAL*2);
 
-    BOOST_CHECK_EQUAL(success(), golos_publication_tester::downvote(
-                            N(brucelee),
-                            N(brucelee),
-                            "permlink",
-                            123));
-    produce_blocks(VOTE_OPERATION_INTERVAL*2);
+    BOOST_CHECK_EQUAL(err.vote_same_weight, post.downvote(N(brucelee), N(brucelee), "permlink", 123));
+    BOOST_CHECK_EQUAL(err.no_message, post.downvote(N(brucelee), N(jackiechan), "permlink", 111));
+    BOOST_CHECK_EQUAL(err.vote_weight_le0, post.downvote(N(brucelee), N(brucelee), "permlink", -333));
+    BOOST_CHECK_EQUAL(err.vote_weight_sign, post.downvote(N(brucelee), N(brucelee), "permlink", 0));
+    BOOST_CHECK_EQUAL(success(), post.downvote(N(brucelee), N(brucelee), "permlink", cfg::_100percent));
+    produce_blocks(cfg::VOTE_OPERATION_INTERVAL*2);
 
-    BOOST_CHECK_EQUAL(error("assertion failure with message: Vote with the same weight has already existed."), golos_publication_tester::downvote(
-                            N(brucelee),
-                            N(brucelee),
-                            "permlink",
-                            123));
-    produce_blocks(VOTE_OPERATION_INTERVAL*2);
+    BOOST_CHECK_EQUAL(err.vote_weight_gt100, post.downvote(N(brucelee), N(brucelee), "permlink", cfg::_100percent+1));
+    BOOST_CHECK_EQUAL(success(), post.downvote(N(jackiechan), N(brucelee), "permlink", 111));
+    produce_blocks(cfg::VOTE_OPERATION_INTERVAL*2);
+    BOOST_CHECK_EQUAL(success(), post.downvote(N(jackiechan), N(brucelee), "permlink", 222));
+    produce_blocks(cfg::VOTE_OPERATION_INTERVAL*2);
+    BOOST_CHECK_EQUAL(success(), post.downvote(N(jackiechan), N(brucelee), "permlink", 333));
+    produce_blocks(cfg::VOTE_OPERATION_INTERVAL*2);
+    BOOST_CHECK_EQUAL(success(), post.downvote(N(jackiechan), N(brucelee), "permlink", 444));
+    produce_blocks(cfg::VOTE_OPERATION_INTERVAL*2);
+    BOOST_CHECK_EQUAL(success(), post.downvote(N(jackiechan), N(brucelee), "permlink", 555));
+    produce_blocks(cfg::VOTE_OPERATION_INTERVAL*2);
 
-    BOOST_CHECK_EQUAL(error("assertion failure with message: Message doesn't exist."), golos_publication_tester::downvote(
-                            N(brucelee),
-                            N(jackiechan),
-                            "permlink",
-                            111));
-    produce_blocks(VOTE_OPERATION_INTERVAL*2);
+    auto vote = post.get_vote(N(brucelee), 1);
+    BOOST_CHECK_EQUAL(vote["count"].as<int64_t>(), 5);
+    BOOST_CHECK_EQUAL(err.no_revote, post.downvote(N(jackiechan), N(brucelee), "permlink", 777));
 
-    BOOST_CHECK_EQUAL(error("assertion failure with message: The weight sign can't be negative."), golos_publication_tester::downvote(
-                            N(brucelee),
-                            N(brucelee),
-                            "permlink",
-                            -333));
-    produce_blocks(VOTE_OPERATION_INTERVAL*2);
-
-    BOOST_CHECK_EQUAL(error("assertion failure with message: The weight sign can't be negative."), golos_publication_tester::downvote(
-                            N(brucelee),
-                            N(brucelee),
-                            "permlink",
-                            0));
-    produce_blocks(VOTE_OPERATION_INTERVAL*2);
-
-    BOOST_CHECK_EQUAL(success(), golos_publication_tester::downvote(
-                            N(brucelee),
-                            N(brucelee),
-                            "permlink",
-                            10000));
-    produce_blocks(VOTE_OPERATION_INTERVAL*2);
-
-    BOOST_CHECK_EQUAL(error("assertion failure with message: The weight can't be more than 100%."), golos_publication_tester::downvote(
-                            N(brucelee),
-                            N(brucelee),
-                            "permlink",
-                            10001));
-    produce_blocks(VOTE_OPERATION_INTERVAL*2);
-
-    BOOST_CHECK_EQUAL(success(), golos_publication_tester::downvote(
-                            N(jackiechan),
-                            N(brucelee),
-                            "permlink",
-                            111));
-    produce_blocks(VOTE_OPERATION_INTERVAL*2);
-
-    BOOST_CHECK_EQUAL(success(), golos_publication_tester::downvote(
-                            N(jackiechan),
-                            N(brucelee),
-                            "permlink",
-                            222));
-    produce_blocks(VOTE_OPERATION_INTERVAL*2);
-
-    BOOST_CHECK_EQUAL(success(), golos_publication_tester::downvote(
-                            N(jackiechan),
-                            N(brucelee),
-                            "permlink",
-                            333));
-    produce_blocks(VOTE_OPERATION_INTERVAL*2);
-
-    BOOST_CHECK_EQUAL(success(), golos_publication_tester::downvote(
-                            N(jackiechan),
-                            N(brucelee),
-                            "permlink",
-                            444));
-    produce_blocks(VOTE_OPERATION_INTERVAL*2);
-
-    BOOST_CHECK_EQUAL(success(), golos_publication_tester::downvote(
-                            N(jackiechan),
-                            N(brucelee),
-                            "permlink",
-                            555));
-    produce_blocks(VOTE_OPERATION_INTERVAL*2);
-
-    auto vote_stats = get_vote(N(brucelee), 1);
-    BOOST_CHECK_EQUAL(fc::variant(vote_stats).get_object()["count"].as<int64_t>(), 5);
-
-    BOOST_CHECK_EQUAL(error("assertion failure with message: You can't revote anymore."), golos_publication_tester::downvote(
-                            N(jackiechan),
-                            N(brucelee),
-                            "permlink",
-                            777));
-    produce_blocks(CLOSE_MESSAGE_PERIOD*2);
-
-    BOOST_CHECK_EQUAL(success(), golos_publication_tester::downvote(
-                            N(jackiechan),
-                            N(brucelee),
-                            "permlink",
-                            777));
-
-    {
-        auto vote_stats = get_vote(N(brucelee), 1);
-        BOOST_CHECK_EQUAL(fc::variant(vote_stats).get_object()["count"].as<int64_t>(), -1);
-    }
+    produce_blocks(cfg::CLOSE_MESSAGE_PERIOD*2);
+    BOOST_CHECK_EQUAL(success(), post.downvote(N(jackiechan), N(brucelee), "permlink", 777));
+    vote = post.get_vote(N(brucelee), 1);
+    BOOST_CHECK_EQUAL(vote["count"].as<int64_t>(), -1);
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE(unvote, golos_publication_tester) try {
     BOOST_TEST_MESSAGE("Unvote testing.");
     init();
 
-    BOOST_CHECK_EQUAL(success(), golos_publication_tester::create_message(
-                            N(brucelee),
-                            "permlink"));
+    // TODO: test fail on initial unvote
+    BOOST_CHECK_EQUAL(success(), post.create_msg(N(brucelee), "permlink"));
+    BOOST_CHECK_EQUAL(success(), post.upvote(N(brucelee), N(brucelee), "permlink", 123));
+    produce_blocks(cfg::VOTE_OPERATION_INTERVAL*2);
+    BOOST_CHECK_EQUAL(success(), post.unvote(N(brucelee), N(brucelee), "permlink"));
 
-    BOOST_CHECK_EQUAL(success(), golos_publication_tester::upvote(
-                            N(brucelee),
-                            N(brucelee),
-                            "permlink",
-                            123));
-    produce_blocks(VOTE_OPERATION_INTERVAL*2);
+    BOOST_CHECK_EQUAL(success(), post.downvote(N(brucelee), N(brucelee), "permlink", 333));
+    produce_blocks(cfg::VOTE_OPERATION_INTERVAL*2);
+    BOOST_CHECK_EQUAL(success(), post.unvote(N(brucelee), N(brucelee), "permlink"));
 
-    BOOST_CHECK_EQUAL(success(), golos_publication_tester::unvote(
-                            N(brucelee),
-                            N(brucelee),
-                            "permlink"));
-
-    {
-        BOOST_CHECK_EQUAL(success(), golos_publication_tester::downvote(
-                                N(brucelee),
-                                N(brucelee),
-                                "permlink",
-                                333));
-        produce_blocks(VOTE_OPERATION_INTERVAL*2);
-
-        BOOST_CHECK_EQUAL(success(), golos_publication_tester::unvote(
-                                N(brucelee),
-                                N(brucelee),
-                                "permlink"));
-    }
-
-    produce_blocks(VOTE_OPERATION_INTERVAL*2);
-    BOOST_CHECK_EQUAL(error("assertion failure with message: Vote with the same weight has already existed."), golos_publication_tester::unvote(
-                            N(brucelee),
-                            N(brucelee),
-                            "permlink"));
-
-    BOOST_CHECK_EQUAL(error("assertion failure with message: Message doesn't exist."), golos_publication_tester::unvote(
-                            N(brucelee),
-                            N(jackiechan),
-                            "permlink1"));
-    produce_blocks(VOTE_OPERATION_INTERVAL*2);
+    produce_blocks(cfg::VOTE_OPERATION_INTERVAL*2);
+    BOOST_CHECK_EQUAL(err.vote_same_weight, post.unvote(N(brucelee), N(brucelee), "permlink"));
+    BOOST_CHECK_EQUAL(err.no_message, post.unvote(N(brucelee), N(jackiechan), "permlink1"));
+    produce_blocks(cfg::VOTE_OPERATION_INTERVAL*2);
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE(mixed_vote_test, golos_publication_tester) try {
     BOOST_TEST_MESSAGE("Mixed vote testing.");
     init();
 
-    BOOST_CHECK_EQUAL(success(), golos_publication_tester::create_message(
-                            N(brucelee),
-                            "permlink"));
+    BOOST_CHECK_EQUAL(success(), post.create_msg(N(brucelee), "permlink"));
+    BOOST_CHECK_EQUAL(success(), post.downvote(N(brucelee), N(brucelee), "permlink", 123));
+    produce_blocks(cfg::VOTE_OPERATION_INTERVAL*2);
+    BOOST_CHECK_EQUAL(success(), post.upvote(N(brucelee), N(brucelee), "permlink", 321));
+    produce_blocks(cfg::VOTE_OPERATION_INTERVAL*2);
+    BOOST_CHECK_EQUAL(success(), post.downvote(N(brucelee), N(brucelee), "permlink", 333));
+    produce_blocks(cfg::VOTE_OPERATION_INTERVAL*2);
 
-    BOOST_CHECK_EQUAL(success(), golos_publication_tester::downvote(
-                            N(brucelee),
-                            N(brucelee),
-                            "permlink",
-                            123));
-    produce_blocks(VOTE_OPERATION_INTERVAL*2);
-
-    BOOST_CHECK_EQUAL(success(), golos_publication_tester::upvote(
-                            N(brucelee),
-                            N(brucelee),
-                            "permlink",
-                            321));
-    produce_blocks(VOTE_OPERATION_INTERVAL*2);
-
-    BOOST_CHECK_EQUAL(success(), golos_publication_tester::downvote(
-                            N(brucelee),
-                            N(brucelee),
-                            "permlink",
-                            333));
-    produce_blocks(VOTE_OPERATION_INTERVAL*2);
-
-    auto vote_stats = get_vote(N(brucelee), 0);
-    BOOST_CHECK_EQUAL(fc::variant(vote_stats).get_object()["count"].as<uint64_t>(), 3);
+    auto vote = post.get_vote(N(brucelee), 0);
+    BOOST_CHECK_EQUAL(vote["count"].as<uint64_t>(), 3);
 } FC_LOG_AND_RETHROW()
 
-BOOST_FIXTURE_TEST_CASE(erase_vote_test, golos_publication_tester) try {
-    BOOST_TEST_MESSAGE("Erase vote testing.");
+BOOST_FIXTURE_TEST_CASE(delete_post_with_vote_test, golos_publication_tester) try {
+    BOOST_TEST_MESSAGE("Delete post with vote testing.");   // TODO: move to "delete" test ?
     init();
 
-    BOOST_CHECK_EQUAL(success(), golos_publication_tester::create_message(
-                            N(brucelee),
-                            "permlink"));
-
-    BOOST_CHECK_EQUAL(success(), golos_publication_tester::create_message(
-                            N(brucelee),
-                            "permlink1"));
-
-    BOOST_CHECK_EQUAL(success(), golos_publication_tester::downvote(
-                            N(brucelee),
-                            N(brucelee),
-                            "permlink",
-                            123));
-    produce_blocks(VOTE_OPERATION_INTERVAL*2);
-
-    BOOST_CHECK_EQUAL(success(), golos_publication_tester::downvote(
-                            N(chucknorris),
-                            N(brucelee),
-                            "permlink1",
-                            321));
-    produce_blocks(VOTE_OPERATION_INTERVAL*2);
-
-    BOOST_CHECK_EQUAL(success(), golos_publication_tester::delete_message(
-                            N(brucelee),
-                            "permlink1"));
-    produce_blocks(1);
-
-    BOOST_CHECK_EQUAL(error("assertion failure with message: Vote with the same weight has already existed."), golos_publication_tester::downvote(
-                            N(brucelee),
-                            N(brucelee),
-                            "permlink",
-                            123));
-
-
+    BOOST_CHECK_EQUAL(success(), post.create_msg(N(brucelee), "upvote-me"));
+    BOOST_CHECK_EQUAL(success(), post.create_msg(N(chucknorris), "downvote-me"));
+    BOOST_CHECK_EQUAL(success(), post.upvote(N(chucknorris), N(brucelee), "upvote-me", 321));
+    BOOST_CHECK_EQUAL(success(), post.downvote(N(brucelee), N(chucknorris), "downvote-me", 123));
+    produce_block();
+    BOOST_CHECK_EQUAL(success(), post.delete_msg(N(chucknorris), "downvote-me"));
+    // BOOST_CHECK_EQUAL(err.delete_rshares, post.delete_msg(N(brucelee), "upvote-me"));    // TODO:
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE(nesting_level_test, golos_publication_tester) try {
     BOOST_TEST_MESSAGE("nesting level test.");
     init();
-    BOOST_CHECK_EQUAL(success(), golos_publication_tester::create_message(N(brucelee), "permlink0"));
+    BOOST_CHECK_EQUAL(success(), post.create_msg(N(brucelee), "permlink0"));
     size_t i = 0;
-    for(; i < MAX_COMMENT_DEPTH; i++)
-     BOOST_CHECK_EQUAL(success(), golos_publication_tester::create_message(
-        N(brucelee), "permlink" + std::to_string(i + 1),
-        N(brucelee), "permlink" + std::to_string(i)));
-
-    BOOST_CHECK_EQUAL("assertion failure with message: publication::create_message: level > MAX_COMMENT_DEPTH",
-        golos_publication_tester::create_message(
-            N(brucelee), "permlink" + std::to_string(i + 1),
+    for (; i < cfg::MAX_COMMENT_DEPTH; i++) {
+        BOOST_CHECK_EQUAL(success(), post.create_msg(
+            N(brucelee), "permlink" + std::to_string(i+1),
             N(brucelee), "permlink" + std::to_string(i)));
-
-
+        // produce_blocks(7);
+    }
+    BOOST_CHECK_EQUAL(err.max_comment_depth, post.create_msg(
+        N(brucelee), "permlink" + std::to_string(i+1),
+        N(brucelee), "permlink" + std::to_string(i)));
 } FC_LOG_AND_RETHROW()
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/golos_tester.hpp
+++ b/tests/golos_tester.hpp
@@ -10,12 +10,12 @@ uint64_t hash64(const std::string& arg);
 
 // Note: cannot check nested mvo
 #define CHECK_EQUAL_OBJECTS(left, right) { \
-    auto a = fc::variant(left); \
-    auto b = fc::variant(right); \
-    BOOST_TEST_CHECK(a.is_object()); \
-    BOOST_TEST_CHECK(b.is_object()); \
-    if (a.is_object() && b.is_object()) { \
-        BOOST_CHECK_EQUAL_COLLECTIONS(a.get_object().begin(), a.get_object().end(), b.get_object().begin(), b.get_object().end()); }}
+    auto l = fc::variant(left); \
+    auto r = fc::variant(right); \
+    BOOST_TEST_CHECK(l.is_object()); \
+    BOOST_TEST_CHECK(r.is_object()); \
+    if (l.is_object() && r.is_object()) { \
+        BOOST_CHECK_EQUAL_COLLECTIONS(l.get_object().begin(), l.get_object().end(), r.get_object().begin(), r.get_object().end()); }}
 
 #define CHECK_MATCHING_OBJECT(check, reference) { \
     auto a = fc::variant(reference); \
@@ -50,7 +50,6 @@ protected:
     std::map<account_name, abi_serializer> _abis;
 
 public:
-    golos_tester(): tester(), _chaindb(control->chaindb()) {}
     golos_tester(name code): tester(), _code(code), _chaindb(control->chaindb()) {
         std::cout << "golos_tester()" << std::endl;
     }


### PR DESCRIPTION
+ updated posting tests
    + chaindb and test_apis support
    + error messages as constants instead of literals
    + added missed fields to post object comparer
+ added `update_msg`, `delete_msg` action wrappers and `get_message`, `get_content`, `get_vote` db readers to posting test_api
+ use constants in posting config (instead of defines)
+ link fixes and some clean up of rewards tests

resolves #182