### PR TITLE
Fix vesting-contract tests #195

### DIFF
--- a/common/config.hpp
+++ b/common/config.hpp
@@ -28,5 +28,8 @@ static constexpr int64_t blocks_per_year = int64_t(365)*24*60*60*1000/block_inte
 constexpr int64_t time_to_blocks(int64_t time) {
     return time / (1000 * config::block_interval_ms);
 }
+constexpr int64_t seconds_to_blocks(int64_t sec) {
+    return time_to_blocks(sec * 1e6);
+}
 
 } // golos::config

--- a/golos.emit/include/golos.emit/config.hpp
+++ b/golos.emit/include/golos.emit/config.hpp
@@ -5,4 +5,4 @@ namespace golos { namespace config {
 
 static const auto emit_interval = 15*60;      // 15 minutes
 
-} } // golos::config
+}} // golos::config

--- a/golos.emit/src/golos.emit.cpp
+++ b/golos.emit/src/golos.emit.cpp
@@ -1,7 +1,6 @@
 #include "golos.emit/golos.emit.hpp"
 #include "golos.emit/config.hpp"
 #include <golos.ctrl/golos.ctrl.hpp>
-// #include <golos.vesting/golos.vesting.hpp>
 #include <eosio.token/eosio.token.hpp>
 #include <eosiolib/transaction.hpp>
 

--- a/golos.publication/config.hpp
+++ b/golos.publication/config.hpp
@@ -23,4 +23,4 @@ namespace limit_restorer_domain {//TODO: it will look better in a rule settings
     constexpr fixp_t max_res = fixp_t(100);
 }
 
-}}
+}} // golos::config

--- a/golos.vesting/config.hpp
+++ b/golos.vesting/config.hpp
@@ -1,22 +1,23 @@
 #pragma once
 #include <common/config.hpp>
 
-#define TIMEOUT 3
+namespace golos { namespace config {
 
-#define FRACTION (10000)
-#define FULL_PERSENT (1000000)
+const int vesting_delay_tx_timeout = 3;     // used to re-create deferred txs. TODO: do not create txs on each block
 
-#define NUMBER_OF_CONVERSIONS (13)
-#define TOTAL_TERM_OF_CONCLUSION 15
-//#define TOTAL_TERM_OF_CONCLUSION (604800)
-#define MIN_AMOUNT_VESTING_CONCLUSION (100000)
+const struct vesting_withdraw {
+    const int intervals = 13;                           // VESTING_WITHDRAW_INTERVALS
+    const int interval_seconds = 120;   // 60*60*24*7   // VESTING_WITHDRAW_INTERVAL_SECONDS
+    const int min_amount = 10 * 1e3;    // acc fee * 10
+} vesting_withdraw;
 
-#define MIN_AMOUNT_DELEGATION_VESTING (50000)
-#define MIN_DELEGATION (150000)
-#define MIN_PERIOD_DELEGATION (0)
-#define MAX_PERSENT_DELEGATION (0)
-#define TIME_LIMIT_FOR_RETURN_DELEGATE_VESTING 15
-//#define TIME_LIMIT_FOR_RETURN_DELEGATE_VESTING (604800)
 
-//------------------------------------------
-//TODO:? it seems like most of this stuff should be in vesting_info
+const struct delegation {
+    const int min_amount    = 50000;        // min step
+    const int min_remainder = 150000;
+    const int min_time      = 0;
+    const int max_interest  = 0;
+    const int return_time   = 120;      // 60*60*24*7 = cashout time
+} delegation;
+
+}} // golos::config

--- a/golos.vesting/golos.vesting.hpp
+++ b/golos.vesting/golos.vesting.hpp
@@ -1,9 +1,11 @@
 #pragma once
 #include "objects.hpp"
 
-namespace eosio {
+namespace golos {
 
-class vesting : public eosio::contract {
+using namespace eosio;
+
+class vesting : public contract {
 
   public:
     vesting(account_name self) : contract(self)  {}
@@ -72,4 +74,4 @@ bool vesting::balance_exist(account_name owner, symbol_name sym) const {
 }
 
 
-}
+} // golos

--- a/tests/golos.vesting_test_api.hpp
+++ b/tests/golos.vesting_test_api.hpp
@@ -49,7 +49,9 @@ struct golos_vesting_api: base_contract_api {
         );
     }
 
-    action_result delegate_vesting(account_name sender, account_name recipient, asset quantity, uint16_t interest_rate, uint8_t payout_strategy) {
+    action_result delegate_vesting(account_name sender, account_name recipient, asset quantity,
+        uint16_t interest_rate = 0, uint8_t payout_strategy = 0
+    ) {
         return push(N(delegatevg), sender, args()
             ("sender", sender)
             ("recipient", recipient)
@@ -104,6 +106,10 @@ struct golos_vesting_api: base_contract_api {
 
     std::vector<variant> get_balances(account_name user) {
         return _tester->get_all_chaindb_rows(_code, user, N(balances), false);
+    }
+
+    variant get_convert_obj(account_name from) {
+        return get_struct(_symbol.to_symbol_code().value, N(converttable), from, "convert_of_tokens");
     }
 
     //// helpers

--- a/tests/golos_tester.cpp
+++ b/tests/golos_tester.cpp
@@ -39,7 +39,8 @@ vector<permission> golos_tester::get_account_permissions(account_name a) {
     return r;
 }
 
-base_tester::action_result golos_tester::push_action(
+// this method do produce_block() internaly and checks that chain_has_transaction()
+base_tester::action_result golos_tester::push_and_check_action(
     account_name code,
     action_name name,
     account_name signer,
@@ -51,6 +52,21 @@ base_tester::action_result golos_tester::push_action(
     act.name    = name;
     act.data    = abi.variant_to_binary(abi.get_action_type(name), data, abi_serializer_max_time);
     return base_tester::push_action(std::move(act), uint64_t(signer));
+}
+
+base_tester::action_result golos_tester::push_action(
+    account_name code,
+    action_name name,
+    account_name signer,
+    const variant_object& data
+) {
+    try {
+        base_tester::push_action(code, name, signer, data);
+    } catch (const fc::exception& ex) {
+        edump((ex.to_detail_string()));
+        return error(ex.top_message());
+    }
+    return success();
 }
 
 base_tester::action_result golos_tester::push_action_msig_tx(

--- a/tests/golos_tester.hpp
+++ b/tests/golos_tester.hpp
@@ -61,6 +61,7 @@ public:
 
     std::vector<permission> get_account_permissions(account_name a);
 
+    action_result push_and_check_action(account_name, action_name, account_name, const variant_object&);
     action_result push_action(account_name code, action_name name, account_name signer, const variant_object& data);
     action_result push_action_msig_tx(account_name code, action_name name,
         std::vector<permission_level> perms, std::vector<account_name> signers, const variant_object& data);


### PR DESCRIPTION
1. Fix tests
    + test cases reordered and grouped to be more clear
    + uses config values instead of magic numbers
    + test_api updated with defaults for `delegate_vesting` and new `get_convert_obj` method
    - un-delegation disabled, looks like composite index not ready
2. vesting config now contains constants instead of defines
3. minor improvements to vesting contract
4. To make timing tests controllable `golos_tester::push_action` updated to push action without producing block