### PR TITLE
Implement emission distribution #284, #233, #252

### DIFF
--- a/common/parameter.hpp
+++ b/common/parameter.hpp
@@ -29,7 +29,7 @@ struct parameter {
 
     // used to detect is parameter can be used in median.
     // by default checks if default comparer set, this means parameter can't be used in median
-    virtual bool can_median() const { return !(this < this); }
+    virtual bool can_median() const { return !(*this < *this); }
 };
 
 struct param_helper {

--- a/golos.config/include/golos.config/parameters.hpp
+++ b/golos.config/include/golos.config/parameters.hpp
@@ -31,7 +31,7 @@ struct [[eosio::table]] cfg_state {
 
     static constexpr int params_count = 2;
 };
-using cfg_state_singleton = eosio::singleton<N(cfgparams), cfg_state>;
+using cfg_params_singleton = eosio::singleton<N(cfgparams), cfg_state>;
 
 
 } // golos

--- a/golos.config/src/golos.config.cpp
+++ b/golos.config/src/golos.config.cpp
@@ -31,7 +31,7 @@ void configer::updateparamse(account_name who, std::vector<emit_param> params) {
     param_helper::check_params(params); // TODO: validate using `validateprms` action of related contract
     // INLINE_ACTION_SENDER(contract_class, validateprms)(contract_name, {{_self, N(active)}}, {params});
 
-    emit_state_singleton acc_params{_self, who};
+    emit_params_singleton acc_params{_self, who};
     bool update = acc_params.exists();
     eosio_assert(update || params.size() == emit_state::params_count,
         std::string("must provide all "+std::to_string(emit_state::params_count)+" parameters in initial set").c_str());
@@ -50,7 +50,7 @@ void configer::updateparamse(account_name who, std::vector<emit_param> params) {
 struct emit_state_updater: state_params_update_visitor<emit_state> {
     using state_params_update_visitor::state_params_update_visitor;
 
-    static const int THRESHOLD = 2; // test only; TODO: get from cfg_state_singleton
+    static const int THRESHOLD = 2; // test only; TODO: get from cfg_params_singleton
 
     void operator()(const infrate_params& p) {
         update_state(&emit_state::infrate, THRESHOLD);
@@ -73,11 +73,11 @@ bool configer::is_top_witness(account_name account) {
 }
 
 void configer::recalculate_state(vector<emit_param> changed_params) {
-    emit_state_singleton state{_self, _self};
+    emit_params_singleton state{_self, _self};
     auto s = state.exists() ? state.get() : emit_state{};   // TODO: default state must be created (in counstructor/init)
 
     auto top = get_top_witnesses();
-    auto top_params = param_helper::get_top_params<emit_state_singleton, emit_state>(_self, top);
+    auto top_params = param_helper::get_top_params<emit_params_singleton, emit_state>(_self, top);
     auto v = emit_state_updater(s, top_params);
     for (const auto& param: changed_params) {
         std::visit(v, param);
@@ -117,7 +117,7 @@ void configer::setparams(vector<cfg_param> params) {
     require_auth(_self);
     param_helper::check_params(params);
 
-    cfg_state_singleton state{_self, _self};
+    cfg_params_singleton state{_self, _self};
     auto s = state.exists() ? state.get() : cfg_state{};   // TODO: default state must be created (in counstructor/init)
     auto setter = cfg_params_setter(s);
     bool changed = false;

--- a/golos.ctrl/abi/golos.ctrl.abi
+++ b/golos.ctrl/abi/golos.ctrl.abi
@@ -54,15 +54,7 @@
                 {"type": "uint16", "name": "witness_supermajority"},
                 {"type": "uint16", "name": "witness_majority"},
                 {"type": "uint16", "name": "witness_minority"},
-                {"type": "uint16", "name": "max_witness_votes"},
-
-                {"type": "uint16", "name": "infrate_start"},
-                {"type": "uint16", "name": "infrate_stop"},
-                {"type": "uint32", "name": "infrate_narrowing"},
-                {"type": "uint16", "name": "content_reward"},
-                {"type": "uint16", "name": "vesting_reward"},
-                {"type": "uint16", "name": "workers_reward"},
-                {"type": "account_name", "name": "workers_pool"}
+                {"type": "uint16", "name": "max_witness_votes"}
             ]
         },
         {

--- a/golos.ctrl/include/golos.ctrl/golos.ctrl.hpp
+++ b/golos.ctrl/include/golos.ctrl/golos.ctrl.hpp
@@ -21,27 +21,6 @@ struct [[eosio::table]] properties {
     uint16_t witness_minority = 0;          // 0 = auto
     uint16_t max_witness_votes = 30;        // MAX_ACCOUNT_WITNESS_VOTES
 
-    // emission
-    uint16_t infrate_start = 1500;          // INFLATION_RATE_START_PERCENT
-    uint16_t infrate_stop = 95;             // INFLATION_RATE_STOP_PERCENT
-    uint32_t infrate_narrowing = 250000;    // INFLATION_NARROWING_PERIOD
-    uint16_t content_reward = 6667-667;     // CONTENT_REWARD_PERCENT
-    uint16_t vesting_reward = 2667-267;     // VESTING_FUND_PERCENT
-    uint16_t workers_reward = 1000;         // 10%
-    account_name workers_pool = N(worker);  // TODO: remove from defaults
-
-    void validate_emit_params() const {
-        eosio_assert(infrate_start >= infrate_stop, "infrate_start can not be less than infrate_stop");
-        eosio_assert(content_reward <= config::_100percent, "content reward must be <= 100%");
-        eosio_assert(vesting_reward <= config::_100percent, "vesting reward must be <= 100%");
-        eosio_assert(workers_reward <= config::_100percent, "workers reward must be <= 100%");
-        eosio_assert((content_reward + vesting_reward + workers_reward) <= config::_100percent,
-            "sum of rewards must be <= 100%");
-        eosio_assert(is_account(workers_pool), "workers pool account must exist");
-        // TODO: validate params change (compare with prev values)
-        // TODO: maybe separate params so some settable only on creation and cannot be changed
-    }
-
     // helpers
     bool validate() const;
     uint16_t active_threshold() const;

--- a/golos.ctrl/src/golos.ctrl.cpp
+++ b/golos.ctrl/src/golos.ctrl.cpp
@@ -17,7 +17,6 @@ using std::string;
 bool properties::validate() const {
     eosio_assert(max_witnesses > 0, "max_witnesses cannot be 0");
     eosio_assert(max_witness_votes > 0, "max_witness_votes cannot be 0");
-    validate_emit_params();
     return true;
 }
 

--- a/golos.emit/CMakeLists.txt
+++ b/golos.emit/CMakeLists.txt
@@ -3,7 +3,6 @@ add_executable(golos.emit.wasm ${CMAKE_CURRENT_SOURCE_DIR}/src/golos.emit.cpp)
 target_include_directories(golos.emit.wasm
    PUBLIC
    ${CMAKE_CURRENT_SOURCE_DIR}/include
-   ${CMAKE_CURRENT_SOURCE_DIR}/../golos.ctrl/include
    ${CMAKE_CURRENT_SOURCE_DIR}/../cyberway.contracts/eosio.token/include
    ${CMAKE_CURRENT_SOURCE_DIR}/..)
 

--- a/golos.emit/abi/golos.emit.abi
+++ b/golos.emit/abi/golos.emit.abi
@@ -48,8 +48,6 @@
                 {"type": "uint64", "name": "prev_emit"},
                 {"type": "uint128", "name": "tx_id"},
                 {"type": "uint64", "name": "start_time"},
-                {"type": "account_name", "name": "post_name"},
-                {"type": "account_name", "name": "work_name"},
                 {"type": "bool", "name": "active"}
             ]
         },

--- a/golos.emit/include/golos.emit/golos.emit.hpp
+++ b/golos.emit/include/golos.emit/golos.emit.hpp
@@ -13,8 +13,6 @@ struct [[eosio::table]] state {
     uint64_t prev_emit;
     uint128_t tx_id;
     uint64_t start_time;
-    account_name post_name;     // get from ctrl?
-    account_name work_name;     // get from ctrl?
     bool active;
 };
 using state_singleton = eosio::singleton<N(state), state>;
@@ -34,8 +32,8 @@ public:
 private:
     void recalculate_state(std::vector<emit_param>);
     symbol_type _token;
-    account_name _owner;
     state_singleton _state;
+    emit_params_singleton _cfg;
 
     void schedule_next(state& s, uint32_t delay);
 };

--- a/golos.emit/include/golos.emit/parameters.hpp
+++ b/golos.emit/include/golos.emit/parameters.hpp
@@ -72,7 +72,7 @@ struct [[eosio::table]] emit_state {
 
     static constexpr int params_count = 2;
 };
-using emit_state_singleton = eosio::singleton<N(emitparams), emit_state>;
+using emit_params_singleton = eosio::singleton<N(emitparams), emit_state>;
 
 
 } // golos

--- a/golos.emit/src/golos.emit.cpp
+++ b/golos.emit/src/golos.emit.cpp
@@ -1,6 +1,5 @@
 #include "golos.emit/golos.emit.hpp"
 #include "golos.emit/config.hpp"
-#include <golos.ctrl/golos.ctrl.hpp>
 #include <eosio.token/eosio.token.hpp>
 #include <eosiolib/transaction.hpp>
 
@@ -18,8 +17,8 @@ emission::emission(account_name self, symbol_type token, uint64_t action)
     : contract(self)
     , _token(token)
     , _state(_self, token)
+    , _cfg(_self, _self)
 {
-    _owner = control::get_owner(token);
 }
 
 struct emit_params_setter: set_params_visitor<emit_state> {
@@ -42,51 +41,50 @@ void emission::setparams(vector<emit_param> params) {
     require_auth(_self);
     param_helper::check_params(params);
 
-    emit_state_singleton state{_self, _self};
-    auto update = state.exists();
+    auto update = _cfg.exists();
     eosio_assert(update || params.size() == emit_state::params_count, "must provide all parameters in initial set");
-    auto s = update ? state.get() : emit_state{};
+    auto s = update ? _cfg.get() : emit_state{};
     auto setter = emit_params_setter(s);
     bool changed = false;
     for (const auto& param: params) {
         changed |= std::visit(setter, param);   // why we have no ||= ?
     }
     eosio_assert(changed, "at least one parameter must change");    // don't add actions, which do nothing
-    state.set(setter.state, _self);
+    _cfg.set(setter.state, _self);
 }
 
 
 void emission::start() {
-    require_auth(_owner);
+    // TODO: disallow if no initial parameters set
+    require_auth(_self);
+    auto now = current_time();
     state s = {
-        .post_name = _owner,
-        // .work_name = p.workers_pool,
-        .start_time = current_time(),
-        .prev_emit = current_time() - config::emit_interval*1000'000   // instant emit. TODO: maybe delay on first start?
+        .start_time = now,
+        .prev_emit = now - config::emit_interval*1000'000   // instant emit. TODO: maybe delay on first start?
     };
-    s = _state.get_or_create(_owner, s);
+    s = _state.get_or_create(_self, s);
     eosio_assert(!s.active, "already active");
     s.active = true;
 
-    uint32_t elapsed = (current_time() - s.prev_emit) / 1e6;
+    uint32_t elapsed = (now - s.prev_emit) / 1e6;
     auto delay = elapsed < config::emit_interval ? config::emit_interval - elapsed : 0;
     schedule_next(s, delay);
 }
 
 void emission::stop() {
-    require_auth(_owner);
+    require_auth(_self);
     auto s = _state.get();  // TODO: create own singleton allowing custom assert message
     eosio_assert(s.active, "already stopped");
     auto id = s.tx_id;
     s.active = false;
     s.tx_id = 0;
-    _state.set(s, _owner);
-    if (id)
+    _state.set(s, _self);
+    if (id) {
         cancel_deferred(id);
+    }
 }
 
 void emission::emit() {
-    // eosio_assert(!_has_props, "this token already created");
     require_auth(_self);
     auto s = _state.get();
     eosio_assert(s.active, "emit called in inactive state");    // impossible?
@@ -98,47 +96,44 @@ void emission::emit() {
     }
     // TODO: maybe limit elapsed to avoid instant high value emission
 
-    auto p = control::get_params(_token);
-    auto narrowed = int64_t((now - s.start_time)/1000000 / p.infrate_narrowing);
-    int64_t infrate = std::max(int64_t(p.infrate_start) - narrowed, int64_t(p.infrate_stop));
+    auto pools = _cfg.get().pools.pools;
+    auto infrate = _cfg.get().infrate;
+    auto narrowed = int64_t((now - s.start_time)/1000000 / infrate.narrowing);
+    int64_t inf_rate = std::max(int64_t(infrate.start) - narrowed, int64_t(infrate.stop));
 
     auto token = eosio::token(config::token_name);
     auto new_tokens =
-        token.get_supply(_token.name()).amount * infrate * time_to_blocks(elapsed)
+        token.get_supply(_token.name()).amount * inf_rate * time_to_blocks(elapsed)
         / (int64_t(config::blocks_per_year) * config::_100percent);
-    auto content_reward = new_tokens * p.content_reward / config::_100percent;
-    auto vesting_reward = new_tokens * p.vesting_reward / config::_100percent;
-    auto workers_reward = new_tokens * p.workers_reward / config::_100percent;
-    auto witness_reward = new_tokens - content_reward - vesting_reward - workers_reward; /// Remaining 6% to witness pay
-    eosio_assert(witness_reward >= 0, "bad reward percents params");    // impossible, TODO: remove after tests
 
     if (new_tokens > 0) {
-#define TRANSFER(to, amount, memo) if (amount > 0) { \
-    INLINE_ACTION_SENDER(eosio::token, transfer)(config::token_name, {from, N(active)}, \
-        {from, to, asset(amount, _token), memo}); \
-}
+        const auto issue_memo = "emission"; // TODO: make configurable?
+        const auto trans_memo = "emission";
         auto from = _self;
-        INLINE_ACTION_SENDER(eosio::token, issue)(config::token_name, {{_owner, N(active)}},
-            {from, asset(new_tokens, _token), "emission"});
+        INLINE_ACTION_SENDER(eosio::token, issue)(config::token_name, {{_self, N(active)}},
+            {from, asset(new_tokens, _token), issue_memo});
 
-        // 1. witness reward can have remainder after division, it stay in content pool
-        // 2. if there less than max witnesses, their reward stay in content pool
-        content_reward += witness_reward;
-        witness_reward /= p.max_witnesses;
-        if (witness_reward > 0) {
-            auto top = control::get_top_witnesses(_token);
-            for (const auto& w: top) {
-                // TODO: maybe reimplement as claim to avoid missing balance asserts (or skip witnesses without balances)
-                TRANSFER(w, witness_reward, "emission");
-                content_reward -= witness_reward;
+        auto transfer = [&](auto from, auto to, auto amount) {
+            if (amount > 0) {
+                auto memo = to == config::vesting_name ? "" : trans_memo;   // vesting contract requires empty memo to add to supply
+                INLINE_ACTION_SENDER(eosio::token, transfer)(config::token_name, {from, N(active)}, \
+                    {from, to, asset(amount, _token), memo}); \
             }
+        };
+        account_name remainder = N();
+        for (const auto& pool: pools) {
+            if (pool.percent == 0) {
+                remainder = pool.name;
+                continue;
+            }
+            auto reward = new_tokens * pool.percent / config::_100percent;
+            eosio_assert(reward <= new_tokens, "SYSTEM: not enough tokens to pay emission reward"); // must not happen
+            transfer(from, pool.name, reward);
+            new_tokens -= reward;
         }
-
-        TRANSFER(_owner, content_reward, "emission");
-        TRANSFER(config::vesting_name, vesting_reward, ""); // memo must be empty to add to supply
-        TRANSFER(p.workers_pool, workers_reward, "emission");
-
-#undef TRANSFER
+        transfer(from, remainder, new_tokens);
+    } else {
+        print("no emission\n");
     }
 
     s.prev_emit = current_time();
@@ -154,7 +149,7 @@ void emission::schedule_next(state& s, uint32_t delay) {
     trx.send(sender_id, _self);
 
     s.tx_id = sender_id;
-    _state.set(s, _owner);
+    _state.set(s, _self);
 }
 
 

--- a/golos.publication/golos.publication.cpp
+++ b/golos.publication/golos.publication.cpp
@@ -394,25 +394,25 @@ void publication::set_vote(account_name voter, account_name author, string perml
 
             eosio_assert(weight != vote_itr->weight, "Vote with the same weight has already existed.");
             eosio_assert(vote_itr->count != config::max_vote_changes, "You can't revote anymore.");
-            
+
             atmsp::machine<fixp_t> machine;
             fixp_t rshares = calc_rshares(voter, weight, cur_time, *pool, machine);
             if(rshares > FP(vote_itr->rshares))
                 check_upvote_time(cur_time, mssg_itr->date);
-            
+
             fixp_t new_mssg_rshares = (FP(mssg_itr->state.netshares) - FP(vote_itr->rshares)) + rshares;
             auto rsharesfn_delta = get_delta(machine, FP(mssg_itr->state.netshares), new_mssg_rshares, pool->rules.mainfunc);
-            
+
             pools.modify(*pool, _self, [&](auto &item) {
                 item.state.rshares = ((WP(item.state.rshares) - wdfp_t(FP(vote_itr->rshares))) + wdfp_t(rshares)).data();
                 item.state.rsharesfn = (WP(item.state.rsharesfn) + wdfp_t(rsharesfn_delta)).data();
             });
-            
+
             message_table.modify(mssg_itr, 0, [&]( auto &item ) {
                 item.state.netshares = new_mssg_rshares.data();
                 item.state.sumcuratorsw = (FP(item.state.sumcuratorsw) - FP(vote_itr->curatorsw)).data();
             });
-            
+
             votetable_index.modify(vote_itr, voter, [&]( auto &item ) {
                item.weight = weight;
                item.time = cur_time;
@@ -420,7 +420,7 @@ void publication::set_vote(account_name voter, account_name author, string perml
                item.rshares = rshares.data();
                ++item.count;
             });
-            
+
             return;
         }
         ++vote_itr;

--- a/golos.publication/golos.publication.hpp
+++ b/golos.publication/golos.publication.hpp
@@ -47,7 +47,7 @@ private:
         const atmsp::parser<fixp_t>& pa, atmsp::machine<fixp_t>& machine);
     static fixp_t get_delta(atmsp::machine<fixp_t>& machine, fixp_t old_val, fixp_t new_val,
         const structures::funcinfo& func);
-    
+
     static void check_upvote_time(uint64_t cur_time, uint64_t mssg_date);
     fixp_t calc_rshares(account_name voter, int16_t weight, uint64_t cur_time, const structures::rewardpool& pool, atmsp::machine<fixp_t>& machine);
 };

--- a/tests/golos.emit_test_api.hpp
+++ b/tests/golos.emit_test_api.hpp
@@ -12,6 +12,9 @@ struct golos_emit_api: domain_contract_api<symbol> {
         return push(N(emit), signer, args());
     }
 
+    action_result start() {
+        return start(_code);
+    }
     action_result start(account_name signer) {
         return push(N(start), signer, args());
     }
@@ -41,7 +44,16 @@ struct golos_emit_api: domain_contract_api<symbol> {
     }
 
     variant get_account_params(account_name acc) const {
-        return base_contract_api::get_struct(acc, N(params), N(params), "params");
+        return base_contract_api::get_struct(acc, N(emitparams), N(emitparams), "params");
+    }
+
+    // helpers
+    string pool_json(account_name pool, uint16_t percent) {
+        return string("{'name':'") + name{pool}.to_string() + "','percent':" + std::to_string(percent) + "}";
+    }
+    string infrate_json(uint16_t start, uint16_t stop, uint32_t narrowing = 0) {
+        return string("['inflation_rate',{'start':") + std::to_string(start) + ",'stop':" + std::to_string(stop)
+            + ",'narrowing':" + std::to_string(narrowing) + "}]";
     }
 
 };

--- a/tests/golos.emit_tests.cpp
+++ b/tests/golos.emit_tests.cpp
@@ -108,8 +108,8 @@ public:
     }
 
     void prepare_balances() {
-        BOOST_CHECK_EQUAL(success(), token.create(BLOG, dasset(100500)));
-        BOOST_CHECK_EQUAL(success(), vest.create_vesting(BLOG, _token, {_code}));
+        BOOST_CHECK_EQUAL(success(), token.create(_code, dasset(100500)));
+        BOOST_CHECK_EQUAL(success(), vest.create_vesting(_code, _token, {_code}));
         BOOST_CHECK_EQUAL(success(), vest.open(cfg::vesting_name, _token, cfg::vesting_name));
         vector<std::pair<uint64_t,double>> amounts = {
             {BLOG, 1000}, {cfg::workers_name, 0}, {_alice, 800}, {_bob, 700}, {_carol, 600},
@@ -120,7 +120,7 @@ public:
             auto amount = p.second;
             BOOST_CHECK_EQUAL(success(), vest.open(acc, _token, acc));
             if (amount > 0) {
-                BOOST_CHECK_EQUAL(success(), token.issue(BLOG, acc, dasset(amount), "issue"));
+                BOOST_CHECK_EQUAL(success(), token.issue(_code, acc, dasset(amount), "issue"));
                 BOOST_CHECK_EQUAL(success(), token.transfer(acc, cfg::vesting_name, dasset(amount), "buy vesting"));
             } else {
                 BOOST_CHECK_EQUAL(success(), token.open(acc, _token, acc));
@@ -138,43 +138,54 @@ BOOST_AUTO_TEST_SUITE(golos_emit_tests)
 BOOST_FIXTURE_TEST_CASE(start_emission_test, golos_emit_tester) try {
     BOOST_TEST_MESSAGE("Test emission start");
 
-    BOOST_TEST_MESSAGE("--- prepare control");
+    BOOST_TEST_MESSAGE("--- prepare");
     prepare_ctrl(step_vote_witnesses);
     produce_blocks(10);
+    auto content_pool = emit.pool_json(BLOG, 6667-667);
+    auto vesting_pool = emit.pool_json(cfg::vesting_name, 2667-267);
+    auto witness_pool = emit.pool_json(cfg::control_name, 0);
+    auto workers_pool = emit.pool_json(cfg::workers_name, 1000);
+    auto pools = "{'pools':[" + content_pool + "," + witness_pool + "," + vesting_pool + "," + workers_pool + "]}";
+    auto params = "[" + emit.infrate_json(1500, 95, 250000) + ",['reward_pools'," + pools + "]]";
+    BOOST_CHECK_EQUAL(success(), emit.set_params(params));
 
     BOOST_TEST_MESSAGE("--- start succeed");
-    auto w = witness_vect(_smajor_witn_count);
-    BOOST_CHECK_EQUAL(success(), emit.start(BLOG, w));
+    BOOST_CHECK_EQUAL(success(), emit.start());
+    emit.get_state();
     BOOST_TEST_MESSAGE("--- started");
+    produce_block();    // `emit` being processed in next tx (deferred), go next block to be sure state updated
+    emit.get_params();
     auto t = emit.get_state();
     auto tx = t["tx_id"];
 
     BOOST_TEST_MESSAGE("--- go to block just before emission");
     auto emit_interval = cfg::emit_interval * 1000 / cfg::block_interval_ms;
-    produce_blocks(emit_interval - 1);
+    produce_blocks(emit_interval - 1);      // actually we go to emission block now; TODO: resolve, why deferred tx sometimes applied before get_state() and sometimes we need to go next block
     BOOST_CHECK_EQUAL(tx, emit.get_state()["tx_id"]);
     BOOST_TEST_MESSAGE("--- next block, check emission");
     produce_block();
-    BOOST_CHECK_NE(tx, emit.get_state()["tx_id"]);
-
+    auto tx2 = emit.get_state()["tx_id"];
+    BOOST_CHECK_NE(tx, tx2);
+    produce_block();
+    BOOST_CHECK_EQUAL(tx2, emit.get_state()["tx_id"]);
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE(set_params, golos_emit_tester) try {
     BOOST_TEST_MESSAGE("Test emission parameters");
-    BOOST_TEST_MESSAGE("--- prepare control");
+    BOOST_TEST_MESSAGE("--- prepare");
     prepare_ctrl(step_only_create);
     produce_block();
 
     BOOST_TEST_MESSAGE("--- check that global params not exist");
     BOOST_TEST_CHECK(emit.get_params().is_null());
 
-    string pool0 = "{\"name\":\"zero\",\"percent\":0}";
-    string pool1 = "{\"name\":\"test\",\"percent\":5000}";
-    string pool2 = "{\"name\":\"less\",\"percent\":4999}";
-    string pool3 = "{\"name\":\"more\",\"percent\":5001}";
-    const auto pools = "{\"pools\":[" + pool2 + "," + pool1 + "," + pool0 + "]}";
-    const string infrate = "{\"start\":1,\"stop\":1,\"narrowing\":0}";
-    auto params = "[[\"inflation_rate\"," + infrate + "], [\"reward_pools\"," + pools + "]]";
+    string pool0 = "{'name':'zero','percent':0}";
+    string pool1 = "{'name':'test','percent':5000}";
+    string pool2 = "{'name':'less','percent':4999}";
+    string pool3 = "{'name':'more','percent':5001}";
+    const auto pools = "{'pools':[" + pool2 + "," + pool1 + "," + pool0 + "]}";
+    const string infrate = "{'start':1,'stop':1,'narrowing':0}";
+    auto params = "[['inflation_rate'," + infrate + "], ['reward_pools'," + pools + "]]";
     BOOST_CHECK_EQUAL(err.no_pool_account, emit.set_params(params));
     create_accounts({N(test), N(less), N(zero)});
     produce_block();
@@ -183,13 +194,13 @@ BOOST_FIXTURE_TEST_CASE(set_params, golos_emit_tester) try {
     auto t = emit.get_params();
     BOOST_TEST_MESSAGE("--- " + fc::json::to_string(t));
     BOOST_CHECK_EQUAL(success(), emit.set_params(
-        "[[\"inflation_rate\"," + infrate + "], [\"reward_pools\",{\"pools\":[" +pool0+ "]}]]"
+        "[['inflation_rate'," + infrate + "], ['reward_pools',{'pools':[" +pool0+ "]}]]"
     ));
     t = emit.get_params();
     BOOST_TEST_MESSAGE("--- " + fc::json::to_string(t));
 
     BOOST_CHECK_EQUAL(success(), emit.set_params(
-        "[[\"inflation_rate\",{\"start\":5,\"stop\":5,\"narrowing\":0}], [\"reward_pools\"," + pools + "]]"
+        "[['inflation_rate',{'start':5,'stop':5,'narrowing':0}], ['reward_pools'," + pools + "]]"
     ));
     t = emit.get_params();
     BOOST_TEST_MESSAGE("--- " + fc::json::to_string(t));

--- a/tests/golos.params_tests.cpp
+++ b/tests/golos.params_tests.cpp
@@ -120,14 +120,6 @@ public:
         CHECK_MATCHING_OBJECT(vest.get_balance(_bob), vest.make_balance(700));
         CHECK_MATCHING_OBJECT(vest.get_balance(_w[0]), vest.make_balance(100));
     }
-
-    string pool_json(account_name pool, uint16_t percent) {
-        return string("{'name':'") + name{pool}.to_string() + "','percent':" + std::to_string(percent) + "}";
-    }
-    string infrate_json(uint16_t start, uint16_t stop, uint32_t narrowing = 0) {
-        return string("['inflation_rate',{'start':") + std::to_string(start) + ",'stop':" + std::to_string(stop)
-            + ",'narrowing':" + std::to_string(narrowing) + "}]";
-    }
 };
 
 
@@ -144,10 +136,10 @@ BOOST_FIXTURE_TEST_CASE(set_params, golos_params_tester) try {
 
     BOOST_TEST_MESSAGE("--- check_params: fail on empty parameters, wrong variant order or several copies of the same parameter");
     BOOST_CHECK_EQUAL(err.empty, emit.set_params("[]"));
-    auto pools = "['reward_pools',{'pools':[" + pool_json(_bob,0) + "]}]";
-    auto pools2 = "['reward_pools',{'pools':[" + pool_json(_alice,1000) + "," + pool_json(_bob,0) + "]}]";
-    auto infrate = infrate_json(0,0);
-    auto infrate2 = infrate_json(500,500);
+    auto pools = "['reward_pools',{'pools':[" + emit.pool_json(_bob,0) + "]}]";
+    auto pools2 = "['reward_pools',{'pools':[" + emit.pool_json(_alice,1000) + "," + emit.pool_json(_bob,0) + "]}]";
+    auto infrate = emit.infrate_json(0,0);
+    auto infrate2 = emit.infrate_json(500,500);
     BOOST_CHECK_EQUAL(err.bad_variant_order, emit.set_params("[" + pools + "," + infrate + "]"));
     BOOST_CHECK_EQUAL(err.duplicates, emit.set_params("[" + infrate + "," + infrate + "]"));
     BOOST_CHECK_EQUAL(err.duplicates, emit.set_params("[" + infrate + "," + infrate2 + "]"));
@@ -155,7 +147,7 @@ BOOST_FIXTURE_TEST_CASE(set_params, golos_params_tester) try {
 
     BOOST_TEST_MESSAGE("--- setparams: fail if first call to setparams action contains not all parameters");
     BOOST_CHECK_EQUAL(err.incomplete, emit.set_params("[" + infrate + "]"));
-    BOOST_CHECK_EQUAL(err.incomplete, emit.set_params("[" + infrate_json(1,1) + "]"));
+    BOOST_CHECK_EQUAL(err.incomplete, emit.set_params("[" + emit.infrate_json(1,1) + "]"));
 
     BOOST_TEST_MESSAGE("--- success on valid parameters and changing parameters");
     BOOST_CHECK_EQUAL(success(), emit.set_params("[" + infrate + "," + pools + "]"));


### PR DESCRIPTION
+ Inflation and reward pools settings removed from ctrl #233
+ Emission contract uses new parameters mechanism #252
+ Emission distributes according to new params (flexible pools) #284, witness rewards distribution added in #235
+ updated auths required to emit actions
+ emit no more depends on ctrl
+ fixed params singletons and related tables naming
+ updated emission tests

resolves #233, resolves #252, resolves #284