### PR TITLE
Update vesting smart-contract to use CDT 1.4 #290

### DIFF
--- a/common/config.hpp
+++ b/common/config.hpp
@@ -1,5 +1,13 @@
 #pragma once
 
+#ifndef UNIT_TEST_ENV
+// test env still use N macro, so we continue to use it here
+#   define STRINGIFY_(x) #x
+#   define STRINGIFY(x) STRINGIFY_(x)
+#   define N(x) eosio::name(STRINGIFY(x))
+#endif
+
+
 namespace golos { namespace config {
 
 // contracts

--- a/common/parameter.hpp
+++ b/common/parameter.hpp
@@ -5,6 +5,9 @@
 
 namespace golos {
 
+
+using namespace eosio;
+
 template<typename T, int L>
 struct param_wrapper: T {
     param_wrapper() = default;
@@ -33,6 +36,7 @@ struct parameter {
 };
 
 struct param_helper {
+
     template<typename T>
     static void check_params(const std::vector<T>& params) {
         eosio::print("check_params, size: ", params.size(), "\n");
@@ -141,10 +145,10 @@ struct param_helper {
      * @param top - top witnesses
      */
     template<typename Tbl, typename Item>   // TODO: Item can be derived from Tbl
-    static std::vector<Item> get_top_params(account_name code, const std::vector<account_name>& top) {
+    static std::vector<Item> get_top_params(name code, const std::vector<name>& top) {
         std::vector<Item> r;
         for (const auto& w: top) {
-            Tbl p{code, w};                 // NOTE: convention to store parameters in account scope
+            Tbl p{code, w.value};           // NOTE: convention to store parameters in account scope
             if (p.exists())
                 r.emplace_back(p.get());
         }

--- a/common/parameter_ops.hpp
+++ b/common/parameter_ops.hpp
@@ -7,31 +7,6 @@
 namespace golos {
 
 
-// variant deserializer don't implemented in CDT 1.2.x
-template<int I, typename Stream, typename... Ts>
-void deserialize(datastream<Stream>& ds, std::variant<Ts...>& var, int i) {
-    if constexpr (I < std::variant_size_v<std::variant<Ts...>>) {
-        if (i == I) {
-            std::variant_alternative_t<I, std::variant<Ts...>> tmp;
-            ds >> tmp;
-            var = std::move(tmp);
-        } else {
-            deserialize<I+1>(ds,var,i);
-        }
-    } else {
-        eosio_assert(false, "invalid variant index");
-    }
-}
-
-template<typename Stream, typename... Ts>
-inline datastream<Stream>& operator>>(datastream<Stream>& ds, std::variant<Ts...>& var) {
-    unsigned_int index;
-    ds >> index;
-    deserialize<0>(ds,var,index);
-    return ds;
-}
-
-
 ////////////////////////////////////////////////////////////////////////////////
 // param wrapper ops
 

--- a/golos.vesting/golos.vesting.abi
+++ b/golos.vesting/golos.vesting.abi
@@ -1,18 +1,13 @@
 {
   "version": "cyberway::abi/1.0",
-  "types": [
-    {
-      "new_type_name": "account_name",
-      "type": "name"
-    }
-  ],
+  "types": [],
   "structs": [
     {
       "name": "balance_vesting",
       "base": "",
       "fields": [
         {"name": "supply", "type": "asset"},
-        {"name": "issuers", "type": "account_name[]"}
+        {"name": "issuers", "type": "name[]"}
       ]
     },
     {
@@ -57,11 +52,11 @@
         },
         {
           "name": "sender",
-          "type": "account_name"
+          "type": "name"
         },
         {
           "name": "recipient",
-          "type": "account_name"
+          "type": "name"
         },
         {
           "name": "quantity",
@@ -95,7 +90,7 @@
         },
         {
           "name": "recipient",
-          "type": "account_name"
+          "type": "name"
         },
         {
           "name": "number_of_payments",
@@ -121,7 +116,7 @@
       "fields": [
         {
           "name": "sender",
-          "type": "account_name"
+          "type": "name"
         },
         {
           "name": "type",
@@ -139,7 +134,7 @@
         },
         {
           "name": "recipient",
-          "type": "account_name"
+          "type": "name"
         },
         {
           "name": "amount",
@@ -157,11 +152,11 @@
       "fields": [
         {
           "name": "sender",
-          "type": "account_name"
+          "type": "name"
         },
         {
           "name": "recipient",
-          "type": "account_name"
+          "type": "name"
         },
         {
           "name": "quantity",
@@ -175,7 +170,7 @@
       "fields": [
         {
           "name": "issuer",
-          "type": "account_name"
+          "type": "name"
         },
         {
           "name": "quantity",
@@ -183,7 +178,7 @@
         },
         {
           "name": "user",
-          "type": "account_name"
+          "type": "name"
         }
       ]
     },
@@ -193,7 +188,7 @@
       "fields": [
         {
           "name": "owner",
-          "type": "account_name"
+          "type": "name"
         },
         {
           "name": "quantity",
@@ -229,16 +224,16 @@
        "name": "open",
        "base": "",
        "fields": [
-          {"name":"owner", "type":"account_name"},
+          {"name":"owner", "type":"name"},
           {"name":"symbol", "type":"symbol"},
-          {"name":"ram_payer", "type":"account_name"}
+          {"name":"ram_payer", "type":"name"}
        ]
     },
     {
        "name": "close",
        "base": "",
        "fields": [
-          {"name":"owner", "type":"account_name"},
+          {"name":"owner", "type":"name"},
           {"name":"symbol", "type":"symbol"}
        ]
     },
@@ -246,9 +241,9 @@
        "name": "createvest",
        "base": "",
        "fields": [
-          {"name":"creator", "type":"account_name"},
+          {"name":"creator", "type":"name"},
           {"name":"symbol", "type":"symbol"},
-          {"name":"issuers", "type":"account_name[]"}
+          {"name":"issuers", "type":"name[]"}
        ]
     }
   ],

--- a/golos.vesting/golos.vesting.cpp
+++ b/golos.vesting/golos.vesting.cpp
@@ -1,7 +1,6 @@
 #include "golos.vesting.hpp"
 #include "config.hpp"
 #include <eosiolib/transaction.hpp>
-// #include <eosiolib/fixedpoint.hpp>
 #include <eosio.token/eosio.token.hpp>
 
 namespace golos {
@@ -11,43 +10,47 @@ using namespace eosio;
 
 extern "C" {
     void apply(uint64_t receiver, uint64_t code, uint64_t action) {
-        vesting(receiver).apply(code, action);
+        // vesting(receiver).apply(code, action);
+    auto execute_action = [&](const auto fn) {
+        return eosio::execute_action(eosio::name(receiver), eosio::name(code), fn);
+    };
+#define NN(x) N(x).value
+
+    if (NN(transfer) == action && config::token_name.value == code)
+        execute_action(&vesting::on_transfer);
+
+    else if (NN(retire) == action)
+        execute_action(&vesting::retire);
+    else if (NN(unlocklimit) == action)
+        execute_action(&vesting::unlock_limit);
+    else if (NN(convertvg) == action)
+        execute_action(&vesting::convert_vesting);
+    else if (NN(cancelvg) == action)
+        execute_action(&vesting::cancel_convert_vesting);
+    else if (NN(delegatevg) == action)
+        execute_action(&vesting::delegate_vesting);
+    else if (NN(undelegatevg) == action)
+        execute_action(&vesting::undelegate_vesting);
+
+    else if (NN(open) == action)
+        execute_action(&vesting::open);
+    else if (NN(close) == action)
+        execute_action(&vesting::close);
+
+    else if (NN(createvest) == action)
+        execute_action(&vesting::create);
+
+    else if (NN(timeoutrdel) == action)
+        execute_action(&vesting::calculate_delegate_vesting);
+    else if (NN(timeoutconv) == action)
+        execute_action(&vesting::calculate_convert_vesting);
+    else if (NN(timeout) == action)
+        execute_action(&vesting::timeout_delay_trx);
     }
+#undef NN
 }
 
-void vesting::apply(uint64_t code, uint64_t action) {
-    if (N(transfer) == action && N(eosio.token) == code)
-        execute_action(this, &vesting::on_transfer);
-
-    else if (N(retire) == action)
-        execute_action(this, &vesting::retire);
-    else if (N(unlocklimit) == action)
-        execute_action(this, &vesting::unlock_limit);
-    else if (N(convertvg) == action)
-        execute_action(this, &vesting::convert_vesting);
-    else if (N(cancelvg) == action)
-        execute_action(this, &vesting::cancel_convert_vesting);
-    else if (N(delegatevg) == action)
-        execute_action(this, &vesting::delegate_vesting);
-    else if (N(undelegatevg) == action)
-        execute_action(this, &vesting::undelegate_vesting);
-
-    else if (N(open) == action)
-        execute_action(this, &vesting::open);
-    else if (N(close) == action)
-        execute_action(this, &vesting::close);
-
-    else if (N(createvest) == action)
-        execute_action(this, &vesting::create);
-    else if (N(timeoutrdel) == action)
-        calculate_delegate_vesting();
-    else if (N(timeoutconv) == action)
-        calculate_convert_vesting();
-    else if (N(timeout) == action)
-        timeout_delay_trx();
-}
-
-void vesting::on_transfer(account_name from, account_name to, asset quantity, std::string memo) {
+void vesting::on_transfer(name from, name to, asset quantity, std::string memo) {
     if (_self == from) // contract can not buy vesting itself
         return;
 
@@ -58,8 +61,8 @@ void vesting::on_transfer(account_name from, account_name to, asset quantity, st
     eosio_assert(quantity.amount > 0, "must transfer positive quantity");
     // it's notification, so there is no need to validate symbol, eosio.token already checked it
 
-    tables::vesting_table table_vesting(_self, _self);
-    auto vesting = table_vesting.find(quantity.symbol.name());
+    tables::vesting_table table_vesting(_self, _self.value);
+    auto vesting = table_vesting.find(quantity.symbol.code().raw());
     eosio_assert(vesting != table_vesting.end(), "Token not found");
 
     bool from_issuer = std::find(vesting->issuers.begin(), vesting->issuers.end(), from) != vesting->issuers.end();
@@ -68,20 +71,20 @@ void vesting::on_transfer(account_name from, account_name to, asset quantity, st
     }
 
     asset converted = convert_to_vesting(quantity, *vesting);
-    table_vesting.modify(vesting, 0, [&](auto& item) {
+    table_vesting.modify(vesting, name(), [&](auto& item) {
         item.supply += converted;
     });
-    auto receiver = from_issuer ? string_to_name(memo.c_str()) : from;
+    auto receiver = from_issuer ? name(std::string_view(memo)) : from;
     add_balance(receiver, converted, has_auth(to) ? to : from);
 }
 
-void vesting::retire(account_name issuer, asset quantity, account_name user) {
+void vesting::retire(name issuer, asset quantity, name user) {
     require_auth(issuer);
     eosio_assert(quantity.is_valid(), "invalid quantity");
     eosio_assert(quantity.amount > 0, "must retire positive quantity");
 
-    tables::vesting_table table_vesting(_self, _self);
-    auto vesting = table_vesting.find(quantity.symbol.name());
+    tables::vesting_table table_vesting(_self, _self.value);
+    auto vesting = table_vesting.find(quantity.symbol.code().raw());
     eosio_assert(vesting != table_vesting.end(), "Vesting not found");
     eosio_assert(quantity.symbol == vesting->supply.symbol, "symbol precision mismatch");
     bool from_issuer = std::find(vesting->issuers.begin(), vesting->issuers.end(), issuer) != vesting->issuers.end();
@@ -89,24 +92,24 @@ void vesting::retire(account_name issuer, asset quantity, account_name user) {
     eosio_assert(quantity.amount <= vesting->supply.amount, "invalid amount");
 
     sub_balance(user, quantity, true);
-    table_vesting.modify(vesting, 0, [&](auto& item) {
+    table_vesting.modify(vesting, name(), [&](auto& item) {
         item.supply -= quantity;
     });
 }
 
-void vesting::convert_vesting(account_name from, account_name to, asset quantity) {
+void vesting::convert_vesting(name from, name to, asset quantity) {
     require_auth(from);
 
-    tables::account_table account(_self, from);
-    auto vest = account.find(quantity.symbol.name());
+    tables::account_table account(_self, from.value);
+    auto vest = account.find(quantity.symbol.code().raw());
     eosio_assert(vest != account.end(), "unknown asset");
     eosio_assert(vest->vesting.symbol == quantity.symbol, "wrong asset precision");
     eosio_assert(vest->available_vesting().amount >= quantity.amount, "Insufficient funds");
     eosio_assert(config::vesting_withdraw.min_amount <= vest->vesting.amount, "Insufficient funds for converting");
     eosio_assert(quantity.amount > 0, "quantity must be positive");
 
-    tables::convert_table table(_self, quantity.symbol.name());
-    auto record = table.find(from);
+    tables::convert_table table(_self, quantity.symbol.code().raw());
+    auto record = table.find(from.value);
 
     const auto intervals = config::vesting_withdraw.intervals;
     auto fill_record = [&](auto& item) {
@@ -129,31 +132,31 @@ void vesting::convert_vesting(account_name from, account_name to, asset quantity
 }
 
 // TODO: pass symbol name instead of asset
-void vesting::cancel_convert_vesting(account_name sender, asset type) {
+void vesting::cancel_convert_vesting(name sender, asset type) {
     require_auth(sender);
 
-    tables::convert_table table(_self, type.symbol.name());
-    auto record = table.find(sender);
+    tables::convert_table table(_self, type.symbol.code().raw());
+    auto record = table.find(sender.value);
     eosio_assert(record != table.end(), "Not found convert record sender");
 
     table.erase(record);
 }
 
-void vesting::unlock_limit(account_name owner, asset quantity) {
+void vesting::unlock_limit(name owner, asset quantity) {
     require_auth(owner);
     auto sym = quantity.symbol;
     eosio_assert(quantity.is_valid(), "invalid quantity");
     eosio_assert(quantity.amount >= 0, "the number of tokens should not be less than 0");
-    tables::account_table balances(_self, owner);
-    const auto& b = balances.get(sym.name(), "no balance object found");
+    tables::account_table balances(_self, owner.value);
+    const auto& b = balances.get(sym.code().raw(), "no balance object found");
     eosio_assert(b.unlocked_limit.symbol == sym, "symbol precision mismatch");
 
-    balances.modify(b, 0, [&](auto& item) {
+    balances.modify(b, name(), [&](auto& item) {
         item.unlocked_limit = quantity;
     });
 }
 
-void vesting::delegate_vesting(account_name sender, account_name recipient, asset quantity, uint16_t interest_rate, uint8_t payout_strategy) {
+void vesting::delegate_vesting(name sender, name recipient, asset quantity, uint16_t interest_rate, uint8_t payout_strategy) {
     require_auth(sender);
     eosio_assert(sender != recipient, "You can not delegate to yourself");
     eosio_assert(payout_strategy >= 0 && payout_strategy < 2, "not valid value payout_strategy");
@@ -161,13 +164,13 @@ void vesting::delegate_vesting(account_name sender, account_name recipient, asse
     eosio_assert(quantity.amount >= config::delegation.min_amount, "Insufficient funds for delegation");
     eosio_assert(interest_rate <= config::delegation.max_interest, "Exceeded the percentage of delegated vesting");
 
-    auto sname = quantity.symbol.name();
-    tables::account_table account_sender(_self, sender);
+    auto sname = quantity.symbol.code().raw();
+    tables::account_table account_sender(_self, sender.value);
     auto balance_sender = account_sender.find(sname);
     eosio_assert(balance_sender != account_sender.end(), "Not found token");
 
     tables::convert_table convert_tbl(_self, sname);
-    auto convert_obj = convert_tbl.find(sender);
+    auto convert_obj = convert_tbl.find(sender.value);
     if (convert_obj != convert_tbl.end()) {
         auto remains_int = convert_obj->payout_part * convert_obj->number_of_payments;
         auto remains_fract = convert_obj->balance_amount - convert_obj->payout_part * config::vesting_withdraw.intervals;
@@ -180,14 +183,14 @@ void vesting::delegate_vesting(account_name sender, account_name recipient, asse
     });
 
     tables::delegate_table table(_self, sname);
-    auto index_table = table.get_index<N(unique)>();
+    auto index_table = table.get_index<"unique"_n>();
     auto delegate_record = index_table.find(structures::delegate_record::unique_key(sender, recipient));
     if (delegate_record != index_table.end()) {
 
         eosio_assert(delegate_record->interest_rate == interest_rate, "interest_rate does not match");
         eosio_assert(delegate_record->payout_strategy == payout_strategy, "payout_strategy does not match");
 
-        index_table.modify(delegate_record, 0, [&](auto& item){
+        index_table.modify(delegate_record, name(), [&](auto& item){
             item.quantity += quantity;
         });
     } else {
@@ -203,7 +206,7 @@ void vesting::delegate_vesting(account_name sender, account_name recipient, asse
         });
     }
 
-    tables::account_table account_recipient(_self, recipient);
+    tables::account_table account_recipient(_self, recipient.value);
     auto balance_recipient = account_recipient.find(sname);
     eosio_assert(balance_recipient != account_recipient.end(), "Not found balance token vesting");
     account_recipient.modify(balance_recipient, sender, [&](auto& item){
@@ -213,11 +216,11 @@ void vesting::delegate_vesting(account_name sender, account_name recipient, asse
     eosio_assert(balance_recipient->received_vesting.amount >= config::delegation.min_remainder, "delegated vesting withdrawn");
 }
 
-void vesting::undelegate_vesting(account_name sender, account_name recipient, asset quantity) {
+void vesting::undelegate_vesting(name sender, name recipient, asset quantity) {
     require_auth(sender);
 
-    tables::delegate_table table(_self, quantity.symbol.name());
-    auto index_table = table.get_index<N(unique)>();
+    tables::delegate_table table(_self, quantity.symbol.code().raw());
+    auto index_table = table.get_index<"unique"_n>();
     auto delegate_record = index_table.find(structures::delegate_record::unique_key(sender, recipient));
     eosio_assert(delegate_record != index_table.end(), "Not enough delegated vesting");
 
@@ -233,7 +236,7 @@ void vesting::undelegate_vesting(account_name sender, account_name recipient, as
         });
     }
 
-    tables::return_delegate_table table_delegate_vesting(_self, _self);
+    tables::return_delegate_table table_delegate_vesting(_self, _self.value);
     table_delegate_vesting.emplace(sender, [&](auto& item){
         item.id = table_delegate_vesting.available_primary_key();
         item.recipient = sender;
@@ -241,8 +244,8 @@ void vesting::undelegate_vesting(account_name sender, account_name recipient, as
         item.date = time_point_sec(now() + config::delegation.return_time);
     });
 
-    tables::account_table account_recipient(_self, recipient);
-    auto balance = account_recipient.find(quantity.symbol.name());
+    tables::account_table account_recipient(_self, recipient.value);
+    auto balance = account_recipient.find(quantity.symbol.code().raw());
     eosio_assert(balance != account_recipient.end(), "This token is not on the recipient balance sheet");
     account_recipient.modify(balance, sender, [&](auto& item){
         item.received_vesting -= quantity;
@@ -251,12 +254,12 @@ void vesting::undelegate_vesting(account_name sender, account_name recipient, as
     eosio_assert(balance->received_vesting.amount >= config::delegation.min_remainder, "delegated vesting withdrawn");
 }
 
-void vesting::create(account_name creator, symbol_type symbol, std::vector<account_name> issuers) {
+void vesting::create(name creator, symbol symbol, std::vector<name> issuers) {
     require_auth(creator);
-    eosio_assert(creator == token(N(eosio.token)).get_issuer(symbol.name()), "Only token issuer can create it");
+    eosio_assert(creator == token::get_issuer(config::token_name, symbol.code()), "Only token issuer can create it");
 
-    tables::vesting_table table_vesting(_self, _self);
-    auto vesting = table_vesting.find(symbol.name());
+    tables::vesting_table table_vesting(_self, _self.value);
+    auto vesting = table_vesting.find(symbol.code().raw());
     eosio_assert(vesting == table_vesting.end(), "Vesting already exists");
 
     table_vesting.emplace(_self, [&](auto& item){
@@ -267,21 +270,21 @@ void vesting::create(account_name creator, symbol_type symbol, std::vector<accou
 
 void vesting::calculate_convert_vesting() {
     require_auth(_self);
-    tables::vesting_table table_vesting(_self, _self);
+    tables::vesting_table table_vesting(_self, _self.value);
     for (auto vesting : table_vesting) {
-        tables::convert_table table(_self, vesting.supply.symbol.name());
-        auto index = table.get_index<N(payouttime)>();
+        tables::convert_table table(_self, vesting.supply.symbol.code().raw());
+        auto index = table.get_index<"payouttime"_n>();
         for (auto obj = index.cbegin(); obj != index.cend(); ) {
             if (obj->payout_time > time_point_sec(now()))
                 break;
 
             if (obj->number_of_payments > 0) {
-                index.modify(obj, 0, [&](auto& item) {
+                index.modify(obj, name(), [&](auto& item) {
                     item.payout_time = time_point_sec(now() + config::vesting_withdraw.interval_seconds);
                     --item.number_of_payments;
 
-                    tables::account_table account(_self, obj->sender);
-                    auto balance = account.find(obj->payout_part.symbol.name());
+                    tables::account_table account(_self, obj->sender.value);
+                    auto balance = account.find(obj->payout_part.symbol.code().raw());
                     eosio_assert(balance != account.end(), "Vesting balance not found");    // must not happen here, checked earlier
 
                     auto quantity = balance->vesting;
@@ -294,12 +297,12 @@ void vesting::calculate_convert_vesting() {
                     }
 
                     sub_balance(obj->sender, quantity);
-                    auto vest = table_vesting.find(quantity.symbol.name());
+                    auto vest = table_vesting.find(quantity.symbol.code().raw());
                     eosio_assert(vest != table_vesting.end(), "Vesting not found"); // must not happen at this point
-                    table_vesting.modify(vest, 0, [&](auto& item) {
+                    table_vesting.modify(vest, name(), [&](auto& item) {
                         item.supply -= quantity;
                     });
-                    INLINE_ACTION_SENDER(eosio::token, transfer)(N(eosio.token), {_self, N(active)},
+                    INLINE_ACTION_SENDER(eosio::token, transfer)(config::token_name, {_self, config::active_name},
                         {_self, obj->recipient, convert_to_token(quantity, *vest), "Convert vesting"});
                 });
 
@@ -314,16 +317,16 @@ void vesting::calculate_convert_vesting() {
 
 void vesting::calculate_delegate_vesting() {
     require_auth(_self);
-    tables::return_delegate_table table_delegate_vesting(_self, _self);
-    auto index = table_delegate_vesting.get_index<N(date)>();
+    tables::return_delegate_table table_delegate_vesting(_self, _self.value);
+    auto index = table_delegate_vesting.get_index<"date"_n>();
     for (auto obj = index.cbegin(); obj != index.cend();) {
         if (obj->date > time_point_sec(now()))
             break;
 
-        tables::account_table account_recipient(_self, obj->recipient);
-        auto balance_recipient = account_recipient.find(obj->amount.symbol.name());
+        tables::account_table account_recipient(_self, obj->recipient.value);
+        auto balance_recipient = account_recipient.find(obj->amount.symbol.code().raw());
         eosio_assert(balance_recipient != account_recipient.end(), "This token is not on the sender balance sheet");
-        account_recipient.modify(balance_recipient, 0, [&](auto &item){
+        account_recipient.modify(balance_recipient, name(), [&](auto &item){
             item.delegate_vesting -= obj->amount;
         });
 
@@ -331,10 +334,10 @@ void vesting::calculate_delegate_vesting() {
     }
 }
 
-void vesting::open(account_name owner, symbol_type symbol, account_name ram_payer) {
+void vesting::open(name owner, symbol symbol, name ram_payer) {
     require_auth(ram_payer);
-    tables::account_table accounts(_self, owner);
-    auto it = accounts.find(symbol.name());
+    tables::account_table accounts(_self, owner.value);
+    auto it = accounts.find(symbol.code().raw());
     eosio_assert(it == accounts.end(), "already exists");
     accounts.emplace(ram_payer, [&](auto& a) {
         a.vesting.symbol = symbol;
@@ -344,10 +347,10 @@ void vesting::open(account_name owner, symbol_type symbol, account_name ram_paye
     });
 }
 
-void vesting::close(account_name owner, symbol_type symbol) {
+void vesting::close(name owner, symbol symbol) {
     require_auth(owner);
-    tables::account_table account(_self, owner);
-    auto it = account.find(symbol.name());
+    tables::account_table account(_self, owner.value);
+    auto it = account.find(symbol.code().raw());
     eosio_assert(it != account.end(), "Balance row already deleted or never existed. Action won't have any effect");
     eosio_assert(it->vesting.amount == 0, "Cannot close because the balance vesting is not zero");
     eosio_assert(it->delegate_vesting.amount == 0, "Cannot close because the balance delegate vesting is not zero");
@@ -355,27 +358,27 @@ void vesting::close(account_name owner, symbol_type symbol) {
     account.erase(it);
 }
 
-void vesting::notify_balance_change(account_name owner, asset diff) {
+void vesting::notify_balance_change(name owner, asset diff) {
     action(
-        permission_level{_self, N(active)},
+        permission_level{_self, config::active_name},
         golos::config::control_name,
-        N(changevest),
+        "changevest"_n,
         std::make_tuple(diff.symbol, owner, diff)   // TODO: asset is enough, but ctrl uses symbol (1st arg) to detect app
     ).send();
 }
 
-void vesting::sub_balance(account_name owner, asset value, bool retire_mode) {
+void vesting::sub_balance(name owner, asset value, bool retire_mode) {
     eosio_assert(value.amount >= 0, "sub_balance: value.amount < 0");
     if (value.amount == 0)
         return;
-    tables::account_table account(_self, owner);
-    const auto& from = account.get(value.symbol.name(), "no balance object found");
+    tables::account_table account(_self, owner.value);
+    const auto& from = account.get(value.symbol.code().raw(), "no balance object found");
     if (retire_mode)
         eosio_assert(from.unlocked_vesting() >= value, "overdrawn unlocked balance");
     else
         eosio_assert(from.available_vesting() >= value, "overdrawn balance");
 
-    account.modify(from, 0, [&](auto& a) {
+    account.modify(from, name(), [&](auto& a) {
         a.vesting -= value;
         if (retire_mode)
             a.unlocked_limit -= value;
@@ -383,12 +386,12 @@ void vesting::sub_balance(account_name owner, asset value, bool retire_mode) {
     notify_balance_change(owner, -value);
 }
 
-void vesting::add_balance(account_name owner, asset value, account_name ram_payer) {
+void vesting::add_balance(name owner, asset value, name ram_payer) {
     eosio_assert(value.amount >= 0, "add_balance: value.amount < 0");
     if (value.amount == 0)
         return;
-    tables::account_table account(_self, owner);
-    auto to = account.find(value.symbol.name());
+    tables::account_table account(_self, owner.value);
+    auto to = account.find(value.symbol.code().raw());
     if (to == account.end()) {
         account.emplace(ram_payer, [&](auto& a) {
             a.vesting = value;
@@ -396,14 +399,14 @@ void vesting::add_balance(account_name owner, asset value, account_name ram_paye
             a.received_vesting.symbol = value.symbol;
         });
     } else {
-        account.modify(to, 0, [&](auto& a) {
+        account.modify(to, ram_payer, [&](auto& a) {
             a.vesting += value;
         });
     }
     notify_balance_change(owner, value);
 }
 
-int64_t fix_precision(const asset from, const symbol_type to) {
+int64_t fix_precision(const asset from, const symbol to) {
     int a = from.symbol.precision();
     int b = to.precision();
     if (a == b) {
@@ -422,8 +425,8 @@ int64_t fix_precision(const asset from, const symbol_type to) {
 }
 
 const asset vesting::convert_to_token(const asset& src, const structures::vesting_info& vinfo) const {
-    symbol_type sym = src.symbol;
-    auto token_supply = token(N(eosio.token)).get_balance(_self, sym.name());
+    auto sym = src.symbol;
+    auto token_supply = token::get_balance(config::token_name, _self, sym.code());
     // eosio_assert(sym.name() == token_supply.symbol.name() && sym == vinfo.supply.symbol, "The token type does not match");   // guaranteed to be valid here
 
     int64_t amount = vinfo.supply.amount && token_supply.amount
@@ -434,8 +437,8 @@ const asset vesting::convert_to_token(const asset& src, const structures::vestin
 }
 
 const asset vesting::convert_to_vesting(const asset& src, const structures::vesting_info& vinfo) const {
-    symbol_type sym = src.symbol;
-    auto balance = token(N(eosio.token)).get_balance(_self, sym.name()) - src;
+    auto sym = src.symbol;
+    auto balance = token::get_balance(config::token_name, _self, sym.code()) - src;
     // eosio_assert(sym == balance.symbol && sym.name() == vinfo.supply.symbol.name(), "The token type does not match"); //
 
     int64_t amount = vinfo.supply.amount && balance.amount
@@ -447,11 +450,11 @@ const asset vesting::convert_to_vesting(const asset& src, const structures::vest
 void vesting::timeout_delay_trx() {
     require_auth(_self);
     transaction trx;
-    trx.actions.emplace_back(action{permission_level(_self, N(active)), _self, N(timeoutrdel), structures::shash{now()}});
-    trx.actions.emplace_back(action{permission_level(_self, N(active)), _self, N(timeoutconv), structures::shash{now()}});
-    trx.actions.emplace_back(action{permission_level(_self, N(active)), _self, N(timeout),     structures::shash{now()}});
+    trx.actions.emplace_back(action{permission_level(_self, config::active_name), _self, "timeoutrdel"_n, structures::shash{now()}});
+    trx.actions.emplace_back(action{permission_level(_self, config::active_name), _self, "timeoutconv"_n, structures::shash{now()}});
+    trx.actions.emplace_back(action{permission_level(_self, config::active_name), _self, "timeout"_n,     structures::shash{now()}});
     trx.delay_sec = config::vesting_delay_tx_timeout;
-    trx.send(_self, _self);
+    trx.send(_self.value, _self);
 }
 
 

--- a/golos.vesting/golos.vesting.hpp
+++ b/golos.vesting/golos.vesting.hpp
@@ -9,69 +9,68 @@ using namespace eosio;
 class vesting : public contract {
 
 public:
-    vesting(account_name self) : contract(self) {}
-    void apply(uint64_t code, uint64_t action);
+    using contract::contract;
 
-    void on_transfer(account_name from, account_name to, asset quantity, std::string memo);
-    void retire(account_name issuer, asset quantity, account_name user);
-    void unlock_limit(account_name owner, asset quantity);
+    void on_transfer(name from, name to, asset quantity, std::string memo);
+    void retire(name issuer, asset quantity, name user);
+    void unlock_limit(name owner, asset quantity);
 
-    void convert_vesting(account_name from, account_name to, asset quantity);
-    void cancel_convert_vesting(account_name sender, asset type);
-    void delegate_vesting(account_name sender, account_name recipient, asset quantity, uint16_t interest_rate, uint8_t payout_strategy);
-    void undelegate_vesting(account_name sender, account_name recipient, asset quantity);
+    void convert_vesting(name from, name to, asset quantity);
+    void cancel_convert_vesting(name sender, asset type);
+    void delegate_vesting(name sender, name recipient, asset quantity, uint16_t interest_rate, uint8_t payout_strategy);
+    void undelegate_vesting(name sender, name recipient, asset quantity);
 
-    void create(account_name creator, symbol_type symbol, std::vector<account_name> issuers);
+    void create(name creator, symbol symbol, std::vector<name> issuers);
 
-    void open(account_name owner, symbol_type symbol, account_name ram_payer);
-    void close(account_name owner, symbol_type symbol);
-
-    inline asset get_account_vesting(account_name account, symbol_name sym) const;
-    inline asset get_account_effective_vesting(account_name account, symbol_name sym) const;
-    inline asset get_account_available_vesting(account_name account, symbol_name sym) const;
-    inline asset get_account_unlocked_vesting(account_name account, symbol_name sym) const;
-    inline bool balance_exist(account_name owner, symbol_name sym) const;
-
-private:
-    void notify_balance_change(account_name owner, asset diff);
-    void sub_balance(account_name owner, asset value, bool retire_mode = false);
-    void add_balance(account_name owner, asset value, account_name ram_payer);
-
-    const asset convert_to_token(const asset& vesting, const structures::vesting_info& vinfo) const;
-    const asset convert_to_vesting(const asset& token, const structures::vesting_info& vinfo) const;
+    void open(name owner, symbol symbol, name ram_payer);
+    void close(name owner, symbol symbol);
 
     void timeout_delay_trx();
     void calculate_convert_vesting();
     void calculate_delegate_vesting();
+
+    inline asset get_account_vesting(name account, symbol_code sym) const;
+    inline asset get_account_effective_vesting(name account, symbol_code sym) const;
+    inline asset get_account_available_vesting(name account, symbol_code sym) const;
+    inline asset get_account_unlocked_vesting(name account, symbol_code sym) const;
+    inline bool balance_exist(name owner, symbol_code sym) const;
+
+private:
+    void notify_balance_change(name owner, asset diff);
+    void sub_balance(name owner, asset value, bool retire_mode = false);
+    void add_balance(name owner, asset value, name ram_payer);
+
+    const asset convert_to_token(const asset& vesting, const structures::vesting_info& vinfo) const;
+    const asset convert_to_vesting(const asset& token, const structures::vesting_info& vinfo) const;
 };
 
-asset vesting::get_account_vesting(account_name account, symbol_name sym) const {
-    tables::account_table balances(_self, account);
-    const auto& balance = balances.get(sym);
+asset vesting::get_account_vesting(name account, symbol_code sym) const {
+    tables::account_table balances(_self, account.value);
+    const auto& balance = balances.get(sym.raw());
     return balance.vesting;
 }
 
-asset vesting::get_account_available_vesting(account_name account, symbol_name sym) const {
-    tables::account_table balances(_self, account);
-    const auto& balance = balances.get(sym);
+asset vesting::get_account_available_vesting(name account, symbol_code sym) const {
+    tables::account_table balances(_self, account.value);
+    const auto& balance = balances.get(sym.raw());
     return balance.available_vesting();
 }
 
-asset vesting::get_account_effective_vesting(account_name account, symbol_name sym) const {
-    tables::account_table balances(_self, account);
-    const auto& balance = balances.get(sym);
+asset vesting::get_account_effective_vesting(name account, symbol_code sym) const {
+    tables::account_table balances(_self, account.value);
+    const auto& balance = balances.get(sym.raw());
     return balance.effective_vesting();
 }
 
-asset vesting::get_account_unlocked_vesting(account_name account, symbol_name sym) const {
-    tables::account_table balances(_self, account);
-    const auto& balance = balances.get(sym);
+asset vesting::get_account_unlocked_vesting(name account, symbol_code sym) const {
+    tables::account_table balances(_self, account.value);
+    const auto& balance = balances.get(sym.raw());
     return balance.unlocked_vesting();
 }
 
-bool vesting::balance_exist(account_name owner, symbol_name sym) const {
-    tables::account_table balances(_self, owner);
-    return balances.find(sym) != balances.end();
+bool vesting::balance_exist(name owner, symbol_code sym) const {
+    tables::account_table balances(_self, owner.value);
+    return balances.find(sym.raw()) != balances.end();
 }
 
 

--- a/golos.vesting/objects.hpp
+++ b/golos.vesting/objects.hpp
@@ -13,10 +13,10 @@ struct vesting_info {
     vesting_info() = default;
 
     asset supply;
-    std::vector<account_name> issuers;
+    std::vector<name> issuers;
 
     uint64_t primary_key() const {
-        return supply.symbol.name();
+        return supply.symbol.code().raw();
     }
 
     EOSLIB_SERIALIZE(vesting_info, (supply)(issuers))
@@ -31,7 +31,7 @@ struct user_balance {
     asset unlocked_limit;
 
     uint64_t primary_key() const {
-        return vesting.symbol.name();
+        return vesting.symbol.code().raw();
     }
 
     asset available_vesting() const {
@@ -53,16 +53,16 @@ struct delegate_record {
     delegate_record() = default;
 
     uint64_t id;
-    account_name sender;
-    account_name recipient;
+    name sender;
+    name recipient;
     asset quantity;
     asset deductions;
     uint16_t interest_rate;
     uint8_t payout_strategy;
     time_point_sec return_date;
 
-    static uint128_t unique_key(account_name u_sender, account_name u_recipient) {
-        return (uint128_t)u_sender + (((uint128_t)u_recipient)<<64);
+    static uint128_t unique_key(name u_sender, name u_recipient) {
+        return (uint128_t)u_sender.value + (((uint128_t)u_recipient.value)<<64);
     }
 
     auto primary_key() const {
@@ -74,11 +74,11 @@ struct delegate_record {
     }
 
     auto sender_key() const {
-        return sender;
+        return sender.value;
     }
 
     auto recipient_key() const {
-        return recipient;
+        return recipient.value;
     }
 
     EOSLIB_SERIALIZE(delegate_record, (id)(sender)(recipient)(quantity)
@@ -89,7 +89,7 @@ struct return_delegate {
     return_delegate() = default;
 
     uint64_t id;
-    account_name recipient;
+    name recipient;
     asset amount;
     time_point_sec date;
 
@@ -107,15 +107,15 @@ struct return_delegate {
 struct convert_of_tokens {
     convert_of_tokens() = default;
 
-    account_name sender;
-    account_name recipient;
+    name sender;
+    name recipient;
     uint8_t number_of_payments;
     time_point_sec payout_time;
     asset payout_part;
     asset balance_amount;
 
     uint64_t primary_key() const {
-        return sender;
+        return sender.value;
     }
 
     uint64_t payout_time_key() const {

--- a/tests/golos.publication_rewards_tests.cpp
+++ b/tests/golos.publication_rewards_tests.cpp
@@ -1,4 +1,3 @@
-#define UNIT_TEST_ENV
 //#define SHOW_ENABLE
 #include "golos.publication_rewards_types.hpp"
 #include "golos_tester.hpp"

--- a/tests/golos.publication_tests.cpp
+++ b/tests/golos.publication_tests.cpp
@@ -1,4 +1,3 @@
-#define UNIT_TEST_ENV
 #include "golos_tester.hpp"
 #include "golos.posting_test_api.hpp"
 #include "golos.vesting_test_api.hpp"

--- a/tests/golos_tester.hpp
+++ b/tests/golos_tester.hpp
@@ -4,6 +4,8 @@
 #include <eosio/chain/abi_serializer.hpp>
 #include <fc/variant_object.hpp>
 
+#define UNIT_TEST_ENV
+
 namespace fc {
 uint64_t hash64(const std::string& arg);
 }


### PR DESCRIPTION
can be used as reference to update CDT.

requires `cyberway.contracts` submodule to be moved as in #298 

Changes in CDT: https://github.com/GolosChain/cyberway.cdt#differences-between-version-12x-and-version-13x