### PR TITLE
Fix build of tests #336

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,24 @@ project(golos_dapp_contracts VERSION 0.1.0)
 
 set(EOSIO_CDT_VERSION_MIN "1.4")
 set(EOSIO_CDT_VERSION_SOFT_MAX "1.4")
+#set(EOSIO_CDT_VERSION_HARD_MAX "")
 
 find_package(eosio.cdt)
+
+### Check the version of eosio.cdt
+set(VERSION_MATCH_ERROR_MSG "")
+EOSIO_CHECK_VERSION(VERSION_OUTPUT "${EOSIO_CDT_VERSION}"
+                                   "${EOSIO_CDT_VERSION_MIN}"
+                                   "${EOSIO_CDT_VERSION_SOFT_MAX}"
+                                   "${EOSIO_CDT_VERSION_HARD_MAX}"
+                                   VERSION_MATCH_ERROR_MSG)
+if(VERSION_OUTPUT STREQUAL "MATCH")
+   message(STATUS "Using eosio.cdt version ${EOSIO_CDT_VERSION}")
+elseif(VERSION_OUTPUT STREQUAL "WARN")
+   message(WARNING "Using eosio.cdt version ${EOSIO_CDT_VERSION} even though it exceeds the maximum supported version of ${EOSIO_CDT_VERSION_SOFT_MAX}; continuing with configuration, however build may fail.\nIt is recommended to use eosio.cdt version ${EOSIO_CDT_VERSION_SOFT_MAX}.x")
+else() # INVALID OR MISMATCH
+   message(FATAL_ERROR "Found eosio.cdt version ${EOSIO_CDT_VERSION} but it does not satisfy version requirements: ${VERSION_MATCH_ERROR_MSG}\nPlease use eosio.cdt version ${EOSIO_CDT_VERSION_SOFT_MAX}.x")
+endif(VERSION_OUTPUT STREQUAL "MATCH")
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
    set(TEST_BUILD_TYPE "Debug")
@@ -13,25 +29,8 @@ else()
    set(TEST_BUILD_TYPE ${CMAKE_BUILD_TYPE})
 endif()
 
-if(EOSIO_ROOT STREQUAL "" OR NOT EOSIO_ROOT)
-   set(EOSIO_ROOT "/usr/local/eosio")
-endif()
 
-if(EOSIO_CDT_ROOT STREQUAL "" OR NOT EOSIO__ROOT)
-   set(EOSIO_CDT_ROOT "/usr/local/eosio.cdt")
-endif()
-
-list(APPEND CMAKE_MODULE_PATH ${EOSIO_CDT_ROOT}/lib/cmake)
-#include(EosioWasmToolchain)
-
-### Check the version of eosio.cdt
-string(FIND "${EOSIO_CDT_VERSION}" "${EOSIO_CDT_DEPENDENCY}" output)
-
-if (NOT "${output}" EQUAL 0)
-   message(FATAL_ERROR "Incorrect EOSIO.CDT version, please use version ${EOSIO_CDT_DEPENDENCY}.x")
-endif()
-
-include_directories(AFTER ${BOOST_ROOT}/include)
+# include_directories(AFTER ${BOOST_ROOT}/include)
 add_subdirectory(golos.ctrl)
 add_subdirectory(golos.emit)
 add_subdirectory(golos.config)

--- a/common/calclib/fixed_point.h
+++ b/common/calclib/fixed_point.h
@@ -33,6 +33,10 @@ namespace sg14 {
     }
 }
 namespace sg14 {
+#ifdef UNIT_TEST_ENV
+    using int128_t = __int128;
+    using uint128_t = unsigned __int128;
+#endif
     using _digits_type = int;
     template<class T, class Enable = void>
     struct is_composite : std::false_type {

--- a/common/calclib/fixed_point_utils.h
+++ b/common/calclib/fixed_point_utils.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(UNIT_TEST_ENV)
+#ifdef UNIT_TEST_ENV
 #define FIXED_POINT_ASSERT(COND,  MESSAGE) if(!(COND)) { throw std::runtime_error((MESSAGE)); }
 #else
 #define FIXED_POINT_ASSERT(COND,  MESSAGE) eosio_assert((COND), (MESSAGE))
@@ -8,7 +8,11 @@
 
 #include "fixed_point.h"
 
-namespace fixed_point_utils{
+namespace fixed_point_utils {
+
+#ifdef UNIT_TEST_ENV
+    using namespace eosio::testing;
+#endif
 
 using fixp_t = sg14::fixed_point<base_t, -fixed_point_fractional_digits>;
 using wdfp_t = sg14::fixed_point<wide_t, -fixed_point_fractional_digits>;

--- a/common/hash64.hpp
+++ b/common/hash64.hpp
@@ -1,9 +1,11 @@
 #pragma once
+#include <eosiolib/crypto.hpp>
 
-namespace fc {
+namespace golos {
+
 
 uint64_t hash64(const char* buf, size_t len) {
-    eosio::checksum256 hash = sha256(buf, len);
+    eosio::checksum256 hash = eosio::sha256(buf, len);
     return *(reinterpret_cast<const uint64_t *>(&hash));
 }
 
@@ -11,4 +13,5 @@ uint64_t hash64(const std::string& arg) {
     return hash64(arg.c_str(), arg.size());
 }
 
-}
+
+} // golos

--- a/golos.charge/types.h
+++ b/golos.charge/types.h
@@ -2,9 +2,9 @@
 
 #ifdef UNIT_TEST_ENV
 #   define ABI_TABLE
-    using int128_t = __int128;
-    using uint128_t = __uint128_t;
-    using uint8_t = unsigned char;
+#   include <eosio/chain/types.hpp>
+namespace eosio { namespace testing {
+    using namespace eosio::chain;
 #else
 #   define ABI_TABLE [[eosio::table]]
 #endif
@@ -15,6 +15,7 @@ using wide_t = int128_t;
 constexpr int fixed_point_fractional_digits = 12;
 
 #if defined(UNIT_TEST_ENV)
+}} // eosio::testing
 #   include "../common/calclib/fixed_point_utils.h"
 #else
 #   include <common/calclib/fixed_point_utils.h>

--- a/golos.publication/golos.publication.cpp
+++ b/golos.publication/golos.publication.cpp
@@ -89,11 +89,11 @@ void publication::create_message(name account, std::string permlink,
     pools.modify(*pool, _self, [&](auto &item){ item.state.msgs++; });
 
     tables::message_table message_table(_self, account.value);
-    auto message_id = fc::hash64(permlink);
+    auto message_id = hash64(permlink);
     eosio_assert(message_table.find(message_id) == message_table.end(), "This message already exists.");
 
     tables::content_table content_table(_self, account.value);
-    auto parent_id = parentacc ? fc::hash64(parentprmlnk) : 0;
+    auto parent_id = parentacc ? hash64(parentprmlnk) : 0;
 
     uint8_t level = 0;
     if(parentacc)
@@ -148,7 +148,7 @@ void publication::update_message(name account, std::string permlink,
                               std::string jsonmetadata) {
     require_auth(account);
     tables::content_table content_table(_self, account.value);
-    auto cont_itr = content_table.find(fc::hash64(permlink));
+    auto cont_itr = content_table.find(hash64(permlink));
     eosio_assert(cont_itr != content_table.end(), "Content doesn't exist.");
 
     content_table.modify(cont_itr, account, [&]( auto &item ) {
@@ -167,7 +167,7 @@ void publication::delete_message(name account, std::string permlink) {
     tables::content_table content_table(_self, account.value);
     tables::vote_table vote_table(_self, account.value);
 
-    auto message_id = fc::hash64(permlink);
+    auto message_id = hash64(permlink);
     auto mssg_itr = message_table.find(message_id);
     eosio_assert(mssg_itr != message_table.end(), "Message doesn't exist.");
     eosio_assert((mssg_itr->childcount) == 0, "You can't delete comment with child comments.");
@@ -367,7 +367,7 @@ fixp_t publication::calc_rshares(name voter, int16_t weight, uint64_t cur_time, 
 void publication::set_vote(name voter, name author, string permlink, int16_t weight) {
     require_auth(voter);
 
-    uint64_t id = fc::hash64(permlink);
+    uint64_t id = hash64(permlink);
     tables::message_table message_table(_self, author.value);
     auto mssg_itr = message_table.find(id);
     eosio_assert(mssg_itr != message_table.end(), "Message doesn't exist.");

--- a/golos.publication/types.h
+++ b/golos.publication/types.h
@@ -2,14 +2,12 @@
 
 #ifdef UNIT_TEST_ENV
 #   define ABI_TABLE
-    using int128_t = __int128;
-    using uint128_t = __uint128_t;
-    using uint8_t = unsigned char;
+#   include <eosio/chain/types.hpp>
+namespace eosio { namespace testing {
+    using namespace eosio::chain;
 #else
 #   define ABI_TABLE [[eosio::table]]
 #endif
-
-using namespace eosio;
 
 using enum_t = uint8_t;
 using base_t = int64_t;// !if you change it -- don't forget about the abi-file
@@ -37,14 +35,15 @@ struct limitsarg {
     std::vector<int64_t> minvestings;
 };
 
-#ifdef UNIT_TEST_ENV
-FC_REFLECT(limitedact, (chargenum)(restorernum)(cutoffval)(chargeprice))
-FC_REFLECT(limitsarg, (restorers)(limitedacts)(vestingprices)(minvestings))
-#endif
-
 enum class payment_t: enum_t { TOKEN, VESTING };
 
-#if defined(UNIT_TEST_ENV)
+#ifdef UNIT_TEST_ENV
+}} // eosio::testing
+FC_REFLECT(eosio::testing::limitedact, (chargenum)(restorernum)(cutoffval)(chargeprice))
+FC_REFLECT(eosio::testing::limitsarg, (restorers)(limitedacts)(vestingprices)(minvestings))
+#endif
+
+#ifdef UNIT_TEST_ENV
 #   include "../common/calclib/fixed_point_utils.h"
 #else
 #   include <common/calclib/fixed_point_utils.h>

--- a/golos.vesting/golos.vesting.hpp
+++ b/golos.vesting/golos.vesting.hpp
@@ -37,26 +37,26 @@ public:
         tables::account_table balances(code, account.value);
         const auto& balance = balances.get(sym.raw());
         return balance.vesting;
-    };
+    }
     static inline asset get_account_effective_vesting(name code, name account, symbol_code sym) {
         tables::account_table balances(code, account.value);
         const auto& balance = balances.get(sym.raw());
         return balance.effective_vesting();
-    };
+    }
     static inline asset get_account_available_vesting(name code, name account, symbol_code sym) {
         tables::account_table balances(code, account.value);
         const auto& balance = balances.get(sym.raw());
         return balance.available_vesting();
-    };
+    }
     static inline asset get_account_unlocked_vesting(name code, name account, symbol_code sym) {
         tables::account_table balances(code, account.value);
         const auto& balance = balances.get(sym.raw());
         return balance.unlocked_vesting();
-    };
+    }
     static inline bool balance_exist(name code, name owner, symbol_code sym) {
         tables::account_table balances(code, owner.value);
         return balances.find(sym.raw()) != balances.end();
-    };
+    }
 
 private:
     void notify_balance_change(name owner, asset diff);
@@ -65,7 +65,7 @@ private:
 
     const asset convert_to_token(const asset& vesting, const structures::vesting_info& vinfo) const;
     const asset convert_to_vesting(const asset& token, const structures::vesting_info& vinfo) const;
-    
+
     static name get_recipient(const std::string& memo);
 };
 

--- a/tests/golos.publication_rewards_tests.cpp
+++ b/tests/golos.publication_rewards_tests.cpp
@@ -74,7 +74,7 @@ protected:
 
         const string limit_no_power     = amsg("publication::apply_limits: can't post, not enough power");
         const string limit_no_power_vest= amsg("publication::apply_limits: can't post, not enough power, vesting payment is disabled");
-    
+
         const string delete_upvoted     = amsg("Cannot delete a comment with net positive votes.");
     } err;
 
@@ -87,7 +87,7 @@ protected:
         step();
 
         BOOST_CHECK_EQUAL(success(), token.open(_forum_name, _token_symbol, _forum_name));
-        BOOST_CHECK_EQUAL(success(), vest.create_vesting(_issuer, _token_symbol, {_issuer, _forum_name}));
+        BOOST_CHECK_EQUAL(success(), vest.create_vesting(_issuer, _token_symbol, {_issuer, _forum_name}, cfg::control_name));
         step();
 
         BOOST_CHECK_EQUAL(success(), vest.open(_forum_name, _token_symbol, _forum_name));
@@ -348,12 +348,12 @@ public:
 
                     auto curation_payout = p.rules.curatorsprop * payout;
                     double unclaimed_funds = curation_payout;
-                    std::list<std::pair<account_name, double>> cur_rewards;                    
+                    std::list<std::pair<account_name, double>> cur_rewards;
                     double voteshares = 0.0;
                     double curators_fn_sum = 0.0;
                     double prev_curation_fn_val = p.rules.curationfunc(voteshares);
                     for (auto& v : m.votes) {
-                        voteshares += v.voteshares();                        
+                        voteshares += v.voteshares();
                         double curation_fn_val = p.rules.curationfunc(voteshares);
                         double curation_fn_add = v.revote_diff ? 0.0 : curation_fn_val - prev_curation_fn_val;
                         cur_rewards.emplace_back(std::make_pair(v.voter, curation_fn_add *
@@ -461,7 +461,7 @@ public:
         }
         return ret;
     }
-    
+
     action_result delete_message(account_name author, string permlink) {
         return post.delete_msg(author, permlink);
     }
@@ -509,12 +509,12 @@ public:
         }
         return ret;
     }
-    
+
     action_result set_restorer(name user, unsigned char suffix, std::string func_str,
         uint64_t max_prev, uint64_t max_vesting, uint64_t max_elapsed) {
         return charge.set_restorer(user, suffix, func_str, max_prev, max_vesting, max_elapsed);
     }
-    
+
     action_result use(name issuer, name user, unsigned char suffix, uint64_t price, uint64_t cutoff) {
         return charge.use(issuer, user, suffix, price, cutoff);
     }
@@ -590,7 +590,7 @@ BOOST_FIXTURE_TEST_CASE(basic_tests, reward_calcs_tester) try {
     BOOST_CHECK_EQUAL(success(), add_funds_to_forum(100000));
     step();     // push transactions before run() call
     check();
-    
+
     BOOST_TEST_MESSAGE("--- waiting");
     run(seconds(99));   // TODO: remove magic number
     check();
@@ -733,11 +733,11 @@ BOOST_FIXTURE_TEST_CASE(golos_curation_test, reward_calcs_tester) try {
     BOOST_TEST_MESSAGE("--- add_funds_to_forum");
     BOOST_CHECK_EQUAL(success(), add_funds_to_forum(50000));
     check();
-    
+
     BOOST_TEST_MESSAGE("--- create_message: " << name{_users[0]}.to_string());
     BOOST_CHECK_EQUAL(success(), create_message(_users[0], "permlink"));
     check();
-    
+
     for (size_t i = 0; i < 10; i++) {
         BOOST_TEST_MESSAGE("--- " << name{_users[i]}.to_string() << " voted");
         BOOST_CHECK_EQUAL(success(), addvote(_users[i], _users[0], "permlink", 10000));
@@ -745,13 +745,13 @@ BOOST_FIXTURE_TEST_CASE(golos_curation_test, reward_calcs_tester) try {
     }
     run(seconds(170));
     check();
-    
+
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE(charge_test, reward_calcs_tester) try {
     init(1, 1);
-    
-    BOOST_CHECK_EQUAL(success(), set_restorer(_issuer, 'c', "t", 
+
+    BOOST_CHECK_EQUAL(success(), set_restorer(_issuer, 'c', "t",
         10000, static_cast<uint64_t>(std::numeric_limits<fixp_t>::max() / fixp_t(10)), 60 * 60 * 24 * 40));
     for (size_t i = 0; i < 10; i++) {
         BOOST_TEST_MESSAGE("--- use_ " << i);
@@ -771,7 +771,7 @@ BOOST_FIXTURE_TEST_CASE(charge_test, reward_calcs_tester) try {
     BOOST_TEST_MESSAGE("--- use (cutoff == 1000)");
     BOOST_CHECK_EQUAL(success(), use(_issuer, _users[0], 'c', 1000, 1000));
     check();
-    
+
 } FC_LOG_AND_RETHROW()
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/golos.publication_rewards_types.hpp
+++ b/tests/golos.publication_rewards_types.hpp
@@ -1,13 +1,16 @@
 #pragma once
-#include <eosio/chain/types.hpp>
-#include <boost/test/unit_test.hpp>
 #define UNIT_TEST_ENV
 #include "../golos.publication/types.h"
 #include "../golos.publication/config.hpp"
+#include <eosio/chain/types.hpp>
+#include <boost/test/unit_test.hpp>
 #include <string>
 #include <vector>
 #include <list>
 #include <map>
+
+namespace eosio { namespace testing {
+
 
 using namespace eosio::chain;
 
@@ -169,12 +172,10 @@ struct beneficiary {
     account_name account;
     int64_t deductprcnt;
 };
-FC_REFLECT(beneficiary, (account)(deductprcnt))
 
 struct tags {
     std::string tag;
 };
-FC_REFLECT(tags, (tag))
 
 struct message {
     message_key key;
@@ -190,7 +191,7 @@ struct message {
             ret += v.rshares();
         return ret;
     };
-    
+
     message(message_key k, double tokenprop_, double created_, const std::vector<beneficiary>& beneficiaries_, double reward_weight_) :
         key(k), tokenprop(tokenprop_), created(created_), beneficiaries(beneficiaries_), reward_weight(reward_weight_) {};
 };
@@ -364,3 +365,9 @@ struct state {
     std::vector<rewardpool> pools;
     void clear() { balances.clear(); pools.clear(); };
 };
+
+
+}} // eosio::testing
+
+FC_REFLECT(eosio::testing::beneficiary, (account)(deductprcnt))
+FC_REFLECT(eosio::testing::tags, (tag))

--- a/tests/golos_tester.cpp
+++ b/tests/golos_tester.cpp
@@ -6,6 +6,11 @@ namespace eosio { namespace testing {
 using std::vector;
 using std::string;
 
+uint64_t hash64(const std::string& s) {
+    return fc::sha256::hash(s.c_str(), s.size())._hash[0];
+}
+
+
 void golos_tester::install_contract(
     account_name acc, const vector<uint8_t>& wasm, const vector<char>& abi, bool produce
 ) {
@@ -199,10 +204,3 @@ vector<variant> golos_tester::get_all_chaindb_rows(name code, uint64_t scope, na
 }
 
 }} // eosio::tesing
-
-namespace fc {
-uint64_t hash64(const std::string& arg) {
-    return hash64(arg.c_str(), arg.size());
-}
-}
-

--- a/tests/golos_tester.hpp
+++ b/tests/golos_tester.hpp
@@ -6,10 +6,6 @@
 
 #define UNIT_TEST_ENV
 
-namespace fc {
-uint64_t hash64(const std::string& arg);
-}
-
 // Note: cannot check nested mvo
 #define CHECK_EQUAL_OBJECTS(left, right) { \
     auto l = fc::variant(left); \
@@ -30,6 +26,7 @@ uint64_t hash64(const std::string& arg);
 
 namespace eosio { namespace testing {
 
+uint64_t hash64(const std::string& arg);
 
 // TODO: maybe use native db struct
 struct permission {


### PR DESCRIPTION
1. Enclosed some global definitions into namespace to avoid ambiguous
2. Updated root `CMakeLists.txt` to use new version checking and avoid direct `/usr/local/eosio` and `/usr/local/eosio.cdt` paths
3. Moved `hash64` from `fc` namespace
4. Spaces, etc…