### PR TITLE
Support of optimized chaindb cursor in golos_tester #385

### DIFF
--- a/tests/golos_tester.cpp
+++ b/tests/golos_tester.cpp
@@ -181,8 +181,8 @@ variant golos_tester::get_chaindb_singleton(name code, uint64_t scope, name tbl,
 
 vector<variant> golos_tester::get_all_chaindb_rows(name code, uint64_t scope, name tbl, bool strict) const {
     vector<variant> all;
-    auto cursor_ = _chaindb.lower_bound({code, scope, tbl, N(primary)}, nullptr, 0);
-    cyberway::chaindb::cursor_request cursor = {code, cursor_};
+    auto info = _chaindb.lower_bound({code, scope, tbl, N(primary)}, nullptr, 0);
+    cyberway::chaindb::cursor_request cursor = {code, info.cursor};
     auto v = _chaindb.value_at_cursor(cursor);
     if (strict) {
         BOOST_TEST_REQUIRE(!v.is_null());


### PR DESCRIPTION
Note: requires https://github.com/GolosChain/cyberway/commit/8172062b801d1d9aa2ac58bbd88946d8fa3ede43 or newer. Older versions use old implementation